### PR TITLE
Adds pagination to grid, genre, and tag filters

### DIFF
--- a/app/pages/combine.vue
+++ b/app/pages/combine.vue
@@ -11,6 +11,12 @@ const route = useRoute();
 
 const pageSize = 50;
 const currentPage = ref(1);
+const gridPageSize = 18;
+const gridCurrentPage = ref(1);
+const genrePageSize = 32;
+const genreCurrentPage = ref(1);
+const tagPageSize = 40;
+const tagCurrentPage = ref(1);
 
 type Cover = {
   id: number;
@@ -131,6 +137,20 @@ const visibleTags = computed(() => {
   selectedTags.value.forEach((tag) => set.add(tag));
   filteredTags.value.forEach((tag) => set.add(tag));
   return [...set].sort();
+});
+const totalGenrePages = computed(() =>
+  Math.max(1, Math.ceil(allGenres.value.length / genrePageSize))
+);
+const paginatedGenres = computed(() => {
+  const start = (genreCurrentPage.value - 1) * genrePageSize;
+  return allGenres.value.slice(start, start + genrePageSize);
+});
+const totalTagPages = computed(() =>
+  Math.max(1, Math.ceil(visibleTags.value.length / tagPageSize))
+);
+const paginatedTags = computed(() => {
+  const start = (tagCurrentPage.value - 1) * tagPageSize;
+  return visibleTags.value.slice(start, start + tagPageSize);
 });
 
 const filteredEntries = computed(() => {
@@ -310,6 +330,13 @@ const displayedGrid = computed<GridCard[]>(() => {
     };
   });
 });
+const totalGridPages = computed(() =>
+  Math.max(1, Math.ceil(displayedGrid.value.length / gridPageSize))
+);
+const paginatedGrid = computed(() => {
+  const start = (gridCurrentPage.value - 1) * gridPageSize;
+  return displayedGrid.value.slice(start, start + gridPageSize);
+});
 
 const listAnime = computed(() =>
   filteredEntries.value.map((entry) => ({
@@ -348,6 +375,23 @@ const paginatedListAnime = computed(() => {
 watch(totalPages, (next) => {
   if (currentPage.value > next) currentPage.value = next;
 });
+watch(totalGridPages, (next) => {
+  if (gridCurrentPage.value > next) gridCurrentPage.value = next;
+});
+watch(totalGenrePages, (next) => {
+  if (genreCurrentPage.value > next) genreCurrentPage.value = next;
+});
+watch(totalTagPages, (next) => {
+  if (tagCurrentPage.value > next) tagCurrentPage.value = next;
+});
+watch([tagSearch, selectedTags], () => {
+  tagCurrentPage.value = 1;
+});
+watch([genreStates, tagStates], () => {
+  currentPage.value = 1;
+  gridCurrentPage.value = 1;
+  genreCurrentPage.value = 1;
+}, { deep: true });
 
 function cycleState(map: Record<string, FilterState>, key: string) {
   if (!map[key]) map[key] = "include";
@@ -438,7 +482,7 @@ function formatHours(minutes?: number) {
       <div class="flex flex-wrap gap-2">
         <h2 class="w-full font-semibold">{{ t("nav.genres") }}</h2>
         <button
-          v-for="g in allGenres"
+          v-for="g in paginatedGenres"
           :key="g"
           @click="cycleState(genreStates, g)"
           class="px-3 py-2 text-xs rounded-full border"
@@ -451,12 +495,21 @@ function formatHours(minutes?: number) {
           {{ g }}
         </button>
       </div>
+      <div class="flex items-center justify-between text-xs" v-if="totalGenrePages > 1">
+        <button class="px-2 py-1 rounded border" :disabled="genreCurrentPage === 1" @click="genreCurrentPage--">
+          &larr; {{ t("common.back") }}
+        </button>
+        <span>{{ t("common.page") }} {{ genreCurrentPage }} / {{ totalGenrePages }}</span>
+        <button class="px-2 py-1 rounded border" :disabled="genreCurrentPage === totalGenrePages" @click="genreCurrentPage++">
+          {{ t("common.next") }} &rarr;
+        </button>
+      </div>
 
       <input v-model="tagSearch" :placeholder="t('common.searchTags')" class="ui-input w-full px-4" />
 
       <div v-if="tagSearch.trim() || selectedTags.length" class="flex flex-wrap gap-2">
         <button
-          v-for="tag in visibleTags"
+          v-for="tag in paginatedTags"
           :key="tag"
           @click="cycleState(tagStates, tag)"
           class="px-3 py-2 rounded-full text-xs border"
@@ -469,17 +522,37 @@ function formatHours(minutes?: number) {
           {{ tag }}
         </button>
       </div>
+      <div v-if="(tagSearch.trim() || selectedTags.length) && totalTagPages > 1" class="flex items-center justify-between text-xs">
+        <button class="px-2 py-1 rounded border" :disabled="tagCurrentPage === 1" @click="tagCurrentPage--">
+          &larr; {{ t("common.back") }}
+        </button>
+        <span>{{ t("common.page") }} {{ tagCurrentPage }} / {{ totalTagPages }}</span>
+        <button class="px-2 py-1 rounded border" :disabled="tagCurrentPage === totalTagPages" @click="tagCurrentPage++">
+          {{ t("common.next") }} &rarr;
+        </button>
+      </div>
     </section>
 
-    <div v-if="layoutMode === 'grid'" class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+    <div v-if="layoutMode === 'grid'" class="space-y-3">
+      <div class="flex items-center justify-between text-sm mb-2">
+        <button class="px-3 py-1 rounded border" :disabled="gridCurrentPage === 1" @click="gridCurrentPage--">
+          &larr; {{ t("common.back") }}
+        </button>
+        <span>{{ t("common.page") }} {{ gridCurrentPage }} / {{ totalGridPages }}</span>
+        <button class="px-3 py-1 rounded border" :disabled="gridCurrentPage === totalGridPages" @click="gridCurrentPage++">
+          {{ t("common.next") }} &rarr;
+        </button>
+      </div>
+      <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
       <GameCard
-        v-for="(g, i) in displayedGrid"
+        v-for="(g, i) in paginatedGrid"
         :key="g.genre"
-        :rank="i + 1"
+        :rank="(gridCurrentPage - 1) * gridPageSize + i + 1"
         :data="g"
         target="/combine"
         :filter="g.filterType ? { key: g.filterType } : undefined"
       />
+      </div>
     </div>
 
     <div v-else-if="layoutMode === 'list'">

--- a/app/pages/compare.vue
+++ b/app/pages/compare.vue
@@ -35,7 +35,7 @@ const allAnime = ref<CompareAnimeItem[]>([]);
 const search = ref("");
 const seenFilter = ref<SeenFilter>("allUsers");
 
-const pageSize = 50;
+const pageSize = 24;
 const currentPage = ref(1);
 const sortKey = ref<CompareSortKey>("popularity");
 const sortDirection = ref<SortDirection>("desc");
@@ -44,6 +44,10 @@ const genreStates = ref<Record<string, FilterState>>({});
 const tagStates = ref<Record<string, FilterState>>({});
 const tagMinRank = ref<Record<string, number>>({});
 const tagSearch = ref("");
+const genrePageSize = 32;
+const genreCurrentPage = ref(1);
+const tagPageSize = 40;
+const tagCurrentPage = ref(1);
 
 function getEntryTitle(entry: AnimeEntry): { en: string; ro: string; display: string } {
   const en = entry.title.english ?? "";
@@ -191,6 +195,20 @@ const visibleTags = computed(() => {
   filteredTags.value.forEach((tag) => set.add(tag));
   return [...set].sort();
 });
+const totalGenrePages = computed(() =>
+  Math.max(1, Math.ceil(allGenres.value.length / genrePageSize))
+);
+const paginatedGenres = computed(() => {
+  const start = (genreCurrentPage.value - 1) * genrePageSize;
+  return allGenres.value.slice(start, start + genrePageSize);
+});
+const totalTagPages = computed(() =>
+  Math.max(1, Math.ceil(visibleTags.value.length / tagPageSize))
+);
+const paginatedTags = computed(() => {
+  const start = (tagCurrentPage.value - 1) * tagPageSize;
+  return visibleTags.value.slice(start, start + tagPageSize);
+});
 
 const filteredAnime = computed(() => {
   const q = search.value.toLowerCase();
@@ -314,6 +332,22 @@ const paginatedAnime = computed(() => {
 watch(totalPages, (next) => {
   if (currentPage.value > next) currentPage.value = next;
 });
+watch(totalGenrePages, (next) => {
+  if (genreCurrentPage.value > next) genreCurrentPage.value = next;
+});
+watch(totalTagPages, (next) => {
+  if (tagCurrentPage.value > next) tagCurrentPage.value = next;
+});
+watch([search, seenFilter, sortKey, sortDirection], () => {
+  currentPage.value = 1;
+});
+watch([tagSearch, selectedTags], () => {
+  tagCurrentPage.value = 1;
+});
+watch([genreStates, tagStates], () => {
+  currentPage.value = 1;
+  genreCurrentPage.value = 1;
+}, { deep: true });
 
 const animeCount = computed(() => filteredAnime.value.length);
 
@@ -453,7 +487,7 @@ watch(
         <h2 class="text-sm font-semibold text-zinc-300">{{ t("nav.genres") }}</h2>
         <div class="flex flex-wrap gap-2">
           <button
-            v-for="g in allGenres"
+            v-for="g in paginatedGenres"
             :key="g"
             @click="cycleState(genreStates, g)"
             class="px-3 py-1.5 text-xs rounded-full border"
@@ -466,12 +500,21 @@ watch(
             {{ g }}
           </button>
         </div>
+        <div class="flex items-center justify-between text-xs" v-if="totalGenrePages > 1">
+          <button class="px-2 py-1 rounded border" :disabled="genreCurrentPage === 1" @click="genreCurrentPage--">
+            &larr; {{ t("common.back") }}
+          </button>
+          <span>{{ t("common.page") }} {{ genreCurrentPage }} / {{ totalGenrePages }}</span>
+          <button class="px-2 py-1 rounded border" :disabled="genreCurrentPage === totalGenrePages" @click="genreCurrentPage++">
+            {{ t("common.next") }} &rarr;
+          </button>
+        </div>
       </div>
 
       <input v-model="tagSearch" :placeholder="t('common.searchTags')" class="ui-input w-full px-4" />
 
       <div v-if="tagSearch.trim() || selectedTags.length" class="flex flex-wrap gap-2">
-        <div v-for="tag in visibleTags" :key="tag" class="relative">
+        <div v-for="tag in paginatedTags" :key="tag" class="relative">
           <input
             v-if="tagStates[tag] === 'include'"
             type="range"
@@ -502,6 +545,15 @@ watch(
             </span>
           </button>
         </div>
+      </div>
+      <div v-if="(tagSearch.trim() || selectedTags.length) && totalTagPages > 1" class="flex items-center justify-between text-xs">
+        <button class="px-2 py-1 rounded border" :disabled="tagCurrentPage === 1" @click="tagCurrentPage--">
+          &larr; {{ t("common.back") }}
+        </button>
+        <span>{{ t("common.page") }} {{ tagCurrentPage }} / {{ totalTagPages }}</span>
+        <button class="px-2 py-1 rounded border" :disabled="tagCurrentPage === totalTagPages" @click="tagCurrentPage++">
+          {{ t("common.next") }} &rarr;
+        </button>
       </div>
     </section>
 

--- a/app/pages/recommendation.vue
+++ b/app/pages/recommendation.vue
@@ -44,6 +44,10 @@ const allTags = ref<string[]>([]);
 const expandedTagCards = ref<Record<number, boolean>>({});
 const MAX_VISIBLE_TAGS = 8;
 const GRID_VISIBLE_TAGS = 4;
+const pageSize = 24;
+const currentPage = ref(1);
+const filterTagPageSize = 40;
+const filterTagCurrentPage = ref(1);
 
 definePageMeta({ title: "Recommendations", middleware: "auth" });
 
@@ -67,6 +71,13 @@ const visibleTags = computed(() => {
   selectedTags.value.forEach((tag) => set.add(tag));
   filteredTags.value.forEach((tag) => set.add(tag));
   return [...set].sort();
+});
+const filterTagTotalPages = computed(() =>
+  Math.max(1, Math.ceil(visibleTags.value.length / filterTagPageSize))
+);
+const paginatedVisibleTags = computed(() => {
+  const start = (filterTagCurrentPage.value - 1) * filterTagPageSize;
+  return visibleTags.value.slice(start, start + filterTagPageSize);
 });
 
 async function loadRecommendations() {
@@ -122,6 +133,28 @@ onMounted(async () => {
 });
 
 const currentItems = computed(() => items.value[activeTab.value] ?? []);
+const totalPages = computed(() => Math.max(1, Math.ceil(currentItems.value.length / pageSize)));
+const paginatedItems = computed(() => {
+  const start = (currentPage.value - 1) * pageSize;
+  return currentItems.value.slice(start, start + pageSize);
+});
+watch(totalPages, (next) => {
+  if (currentPage.value > next) currentPage.value = next;
+});
+watch([activeTab, layoutMode], () => {
+  currentPage.value = 1;
+});
+watch(
+  [tagSearch, selectedTags, genreStates, filterSeason, seasonYearMin, seasonYearMax, episodesMin, episodesMax, averageScoreMin, includeUpcoming],
+  () => {
+    filterTagCurrentPage.value = 1;
+    currentPage.value = 1;
+  },
+  { deep: true }
+);
+watch(filterTagTotalPages, (next) => {
+  if (filterTagCurrentPage.value > next) filterTagCurrentPage.value = next;
+});
 
 function cycleState(map: Record<string, FilterState>, key: string) {
   if (!map[key]) map[key] = "include";
@@ -276,7 +309,7 @@ function hiddenGridTagCount(item: ApiRecommendationItem) {
 
       <div v-if="tagSearch.trim() || selectedTags.length" class="flex flex-wrap gap-2">
         <button
-          v-for="tag in visibleTags"
+          v-for="tag in paginatedVisibleTags"
           :key="tag"
           @click="cycleState(tagStates, tag)"
           class="px-3 py-1.5 text-xs rounded-full border"
@@ -287,6 +320,19 @@ function hiddenGridTagCount(item: ApiRecommendationItem) {
           }"
         >
           {{ tag }}
+        </button>
+      </div>
+      <div v-if="(tagSearch.trim() || selectedTags.length) && filterTagTotalPages > 1" class="flex items-center justify-between text-xs">
+        <button class="px-2 py-1 rounded border" :disabled="filterTagCurrentPage === 1" @click="filterTagCurrentPage--">
+          &larr; {{ t("common.back") }}
+        </button>
+        <span>{{ t("common.page") }} {{ filterTagCurrentPage }} / {{ filterTagTotalPages }}</span>
+        <button
+          class="px-2 py-1 rounded border"
+          :disabled="filterTagCurrentPage === filterTagTotalPages"
+          @click="filterTagCurrentPage++"
+        >
+          {{ t("common.next") }} &rarr;
         </button>
       </div>
 
@@ -328,16 +374,26 @@ function hiddenGridTagCount(item: ApiRecommendationItem) {
 
     <div v-else-if="error" class="text-red-400">{{ error }}</div>
 
-    <div v-else-if="layoutMode === 'grid'" class="grid gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
+    <div v-else-if="layoutMode === 'grid'" class="space-y-3">
+      <div class="flex items-center justify-between text-sm">
+        <button class="px-3 py-1 rounded border" :disabled="currentPage === 1" @click="currentPage--">
+          &larr; {{ t("common.back") }}
+        </button>
+        <span>{{ t("common.page") }} {{ currentPage }} / {{ totalPages }}</span>
+        <button class="px-3 py-1 rounded border" :disabled="currentPage === totalPages" @click="currentPage++">
+          {{ t("common.next") }} &rarr;
+        </button>
+      </div>
+      <div class="grid gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
       <div
-        v-for="(a, i) in currentItems"
+        v-for="(a, i) in paginatedItems"
         :key="a.id"
         class="ui-card relative h-full overflow-hidden p-3"
       >
         <span
           class="absolute right-3 top-3 inline-flex items-center rounded-full border border-indigo-500/40 bg-indigo-600/10 px-2 py-0.5 text-[11px] font-semibold text-indigo-400"
         >
-          #{{ i + 1 }}
+          #{{ (currentPage - 1) * pageSize + i + 1 }}
         </span>
         <div class="flex gap-3 items-center">
           <ImageWithLoader v-if="a.cover" :src="a.cover" :alt="a.titleEn ?? a.titleRo ?? ''" class="h-24 aspect-2/3 rounded-lg shrink-0" />
@@ -390,11 +446,21 @@ function hiddenGridTagCount(item: ApiRecommendationItem) {
           </div>
         </div>
       </div>
+      </div>
     </div>
 
     <div v-else class="space-y-2">
+      <div class="flex items-center justify-between text-sm">
+        <button class="px-3 py-1 rounded border" :disabled="currentPage === 1" @click="currentPage--">
+          &larr; {{ t("common.back") }}
+        </button>
+        <span>{{ t("common.page") }} {{ currentPage }} / {{ totalPages }}</span>
+        <button class="px-3 py-1 rounded border" :disabled="currentPage === totalPages" @click="currentPage++">
+          {{ t("common.next") }} &rarr;
+        </button>
+      </div>
       <div
-        v-for="a in currentItems"
+        v-for="a in paginatedItems"
         :key="a.id"
         class="flex gap-3 items-center p-3 rounded-xl border border-zinc-800 bg-zinc-900/30"
       >

--- a/app/pages/relations.vue
+++ b/app/pages/relations.vue
@@ -88,7 +88,7 @@ async function loadRelations() {
 
 onMounted(loadRelations);
 
-const pageSize = 20;
+const pageSize = 10;
 const currentPage = ref(1);
 
 const filteredGroups = computed(() => {

--- a/app/pages/tags.vue
+++ b/app/pages/tags.vue
@@ -10,6 +10,10 @@ const route = useRoute();
 
 const pageSize = 50;
 const currentPage = ref(1);
+const gridPageSize = 18;
+const gridCurrentPage = ref(1);
+const filterTagPageSize = 40;
+const filterTagCurrentPage = ref(1);
 
 type TagCover = { id: number; title: string; cover: string };
 type LayoutMode = "grid" | "list";
@@ -109,6 +113,13 @@ const visibleTags = computed(() => {
   const rest = all.filter((tag) => !pinned.includes(tag));
 
   return [...pinned, ...rest.slice(0, 40)];
+});
+const filterTagTotalPages = computed(() =>
+  Math.max(1, Math.ceil(visibleTags.value.length / filterTagPageSize))
+);
+const paginatedVisibleTags = computed(() => {
+  const start = (filterTagCurrentPage.value - 1) * filterTagPageSize;
+  return visibleTags.value.slice(start, start + filterTagPageSize);
 });
 
 const filteredEntries = computed(() => {
@@ -273,6 +284,13 @@ const displayedTags = computed(() => {
     };
   });
 });
+const totalGridPages = computed(() =>
+  Math.max(1, Math.ceil(displayedTags.value.length / gridPageSize))
+);
+const paginatedDisplayedTags = computed(() => {
+  const start = (gridCurrentPage.value - 1) * gridPageSize;
+  return displayedTags.value.slice(start, start + gridPageSize);
+});
 
 const listAnime = computed(() =>
   filteredEntries.value.map((e) => ({
@@ -310,6 +328,23 @@ const paginatedListAnime = computed(() => {
 
 watch(totalPages, (next) => {
   if (currentPage.value > next) currentPage.value = next;
+});
+watch(totalGridPages, (next) => {
+  if (gridCurrentPage.value > next) gridCurrentPage.value = next;
+});
+watch(filterTagTotalPages, (next) => {
+  if (filterTagCurrentPage.value > next) filterTagCurrentPage.value = next;
+});
+watch([tagSearch, selectedTags], () => {
+  filterTagCurrentPage.value = 1;
+});
+watch([listSortKey, listSortDirection], () => {
+  currentPage.value = 1;
+  gridCurrentPage.value = 1;
+});
+watch(layoutMode, () => {
+  currentPage.value = 1;
+  gridCurrentPage.value = 1;
 });
 
 function toggleTag(tag: string) {
@@ -404,7 +439,7 @@ function formatHours(minutes?: number) {
 
       <div v-if="!loading && (tagSearch.trim() || selectedTags.length)" class="flex flex-wrap gap-2">
         <button
-          v-for="tag in visibleTags"
+          v-for="tag in paginatedVisibleTags"
           :key="tag"
           @click="toggleTag(tag)"
           class="px-3 py-2 rounded-full text-xs border"
@@ -417,6 +452,19 @@ function formatHours(minutes?: number) {
           {{ tag }}
         </button>
       </div>
+      <div v-if="!loading && (tagSearch.trim() || selectedTags.length) && filterTagTotalPages > 1" class="flex items-center justify-between text-xs">
+        <button class="px-2 py-1 rounded border" :disabled="filterTagCurrentPage === 1" @click="filterTagCurrentPage--">
+          &larr; {{ t("common.back") }}
+        </button>
+        <span>{{ t("common.page") }} {{ filterTagCurrentPage }} / {{ filterTagTotalPages }}</span>
+        <button
+          class="px-2 py-1 rounded border"
+          :disabled="filterTagCurrentPage === filterTagTotalPages"
+          @click="filterTagCurrentPage++"
+        >
+          {{ t("common.next") }} &rarr;
+        </button>
+      </div>
     </section>
 
     <div v-if="loading" class="flex items-center justify-center py-12">
@@ -424,15 +472,26 @@ function formatHours(minutes?: number) {
     </div>
     <div v-else-if="error" class="text-red-400">{{ error }}</div>
 
-    <div v-if="!loading && !error && layoutMode === 'grid'" class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+    <div v-if="!loading && !error && layoutMode === 'grid'" class="space-y-3">
+      <div class="flex items-center justify-between text-sm mb-2">
+        <button class="px-3 py-1 rounded border" :disabled="gridCurrentPage === 1" @click="gridCurrentPage--">
+          &larr; {{ t("common.back") }}
+        </button>
+        <span>{{ t("common.page") }} {{ gridCurrentPage }} / {{ totalGridPages }}</span>
+        <button class="px-3 py-1 rounded border" :disabled="gridCurrentPage === totalGridPages" @click="gridCurrentPage++">
+          {{ t("common.next") }} &rarr;
+        </button>
+      </div>
+      <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
       <GameCard
-        v-for="(g, i) in displayedTags"
+        v-for="(g, i) in paginatedDisplayedTags"
         :key="g.genre"
-        :rank="i + 1"
+        :rank="(gridCurrentPage - 1) * gridPageSize + i + 1"
         :data="g"
         target="/tags"
         :filter="{ key: 'filter', typeKey: 'filterType', typeValue: 'tag', modeKey: 'filterMode', modeValue: 'include' }"
       />
+      </div>
     </div>
 
     <div v-else-if="!loading && !error">


### PR DESCRIPTION
Improves usability by introducing pagination for grid, genre, and tag lists across several pages. Prevents overwhelming the UI when displaying large sets, ensures controls reset on relevant filter or layout changes, and maintains consistent navigation for users. Also adjusts some default page sizes for better balance.