### PR TITLE
Fix backend reliability: stale lock detection, cache limits, date validation

### DIFF
--- a/server/api/cron/anilist-sync.get.ts
+++ b/server/api/cron/anilist-sync.get.ts
@@ -7,11 +7,20 @@ export default defineEventHandler(async () => {
     where: { key: "anilist_sync_running" },
   });
 
-  if (running?.value === "1") {
-    throw createError({
-      statusCode: 409,
-      statusMessage: "AniList sync already running",
-    });
+  if (running?.value) {
+    const startedAt = Number(running.value);
+    const TWO_HOURS_MS = 2 * 60 * 60 * 1000;
+    if (!isNaN(startedAt) && Date.now() - startedAt < TWO_HOURS_MS) {
+      throw createError({
+        statusCode: 409,
+        statusMessage: "AniList sync already running",
+      });
+    }
+    if (!isNaN(startedAt)) {
+      console.warn(
+        `[AniList Sync] Stale lock detected (started ${new Date(startedAt).toISOString()}), proceeding anyway`
+      );
+    }
   }
 
   return runHourlyAniListSync();

--- a/server/api/private/history.get.ts
+++ b/server/api/private/history.get.ts
@@ -107,6 +107,22 @@ export default defineEventHandler(async (event) => {
     })
   }
 
+  const startDate = new Date(start as string)
+  const endDate = new Date(end as string)
+
+  if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) {
+    throw createError({ statusCode: 400, statusMessage: "Invalid date format" })
+  }
+
+  if (endDate < startDate) {
+    throw createError({ statusCode: 400, statusMessage: "End date must be after start date" })
+  }
+
+  const MAX_RANGE_MS = 366 * 24 * 60 * 60 * 1000 // ~1 year
+  if (endDate.getTime() - startDate.getTime() > MAX_RANGE_MS) {
+    throw createError({ statusCode: 400, statusMessage: "Date range too large (max 1 year)" })
+  }
+
   const toFuzzyDateInt = (dateStr: string) => parseInt(dateStr.replaceAll("-", ""))
 
   const startInt = toFuzzyDateInt(start as string)

--- a/services/anilist/anilistClient.ts
+++ b/services/anilist/anilistClient.ts
@@ -58,9 +58,17 @@ export async function anilistRequest<T>(
   const existing = inFlightRequests.get(key) as Promise<T> | undefined;
   if (existing) return existing;
 
-  const request = performAniListRequest<T>(query, variables, attempt).finally(() => {
+  if (inFlightRequests.size >= 200) {
+    const firstKey = inFlightRequests.keys().next().value;
+    if (firstKey !== undefined) inFlightRequests.delete(firstKey);
+  }
+
+  const promise = performAniListRequest<T>(query, variables, attempt);
+  const cleanup = setTimeout(() => inFlightRequests.delete(key), 60_000);
+  const request = promise.finally(() => {
+    clearTimeout(cleanup);
     inFlightRequests.delete(key);
-  });
+  }) as Promise<T>;
 
   inFlightRequests.set(key, request as Promise<unknown>);
   return request;

--- a/services/anilist/hourlySync.service.ts
+++ b/services/anilist/hourlySync.service.ts
@@ -9,8 +9,8 @@ export async function runHourlyAniListSync() {
 
   await prisma.syncState.upsert({
     where: { key: "anilist_sync_running" },
-    update: { value: "1" },
-    create: { key: "anilist_sync_running", value: "1" },
+    update: { value: String(Date.now()) },
+    create: { key: "anilist_sync_running", value: String(Date.now()) },
   })
 
   const state = await prisma.syncState.findUnique({
@@ -59,12 +59,17 @@ export async function runHourlyAniListSync() {
         `[AniList Sync] checking anime id=${m.id} updatedAt=${m.updatedAt}`
       )
 
-      const changed = await syncAnime(m.id)
-      checked++
+      try {
+        const changed = await syncAnime(m.id)
+        checked++
 
-      if (changed) {
-        written++
-        changedOnThisPage = true
+        if (changed) {
+          written++
+          changedOnThisPage = true
+        }
+      } catch (err) {
+        console.error(`[AniList Sync] Failed to sync anime ${m.id}:`, err)
+        // continue to next anime
       }
 
       if (m.updatedAt > newestSeen) {

--- a/tests/api.cron-anilist-sync.test.ts
+++ b/tests/api.cron-anilist-sync.test.ts
@@ -30,7 +30,7 @@ describe("api/cron/anilist-sync.get", () => {
   })
 
   it("returns 409 when sync is already running", async () => {
-    state.runningValue = "1"
+    state.runningValue = String(Date.now())
     const mod = await import("../server/api/cron/anilist-sync.get")
 
     await expect(mod.default({} as any)).rejects.toMatchObject({


### PR DESCRIPTION
## Summary

- **Stale lock detection**: Cron sync stores a timestamp instead of `"1"` in `anilist_sync_running`. Locks older than 2 hours are bypassed with a warning log, preventing permanent blockage after a crash.
- **In-flight request cache limit**: `anilistClient.ts` caps `inFlightRequests` at 200 entries with a 60s cleanup timeout to prevent unbounded memory growth if a promise never settles.
- **Date validation in history endpoint**: `history.get.ts` validates that dates are valid, end >= start, and range <= 1 year — preventing malformed queries from reaching the DB.
- **Per-anime error isolation**: `hourlySync.service.ts` wraps each `syncAnime()` in try/catch so one failing anime no longer aborts the entire sync run.

## Test plan
- [ ] Run `vitest`
- [ ] Verify cron recovers from a stale lock after a crash
- [ ] Verify history endpoint rejects invalid date inputs with 400