### PR TITLE
Fix backend security: cron auth, input validation, error sanitization, SHA256

### DIFF
--- a/server/api/cron/anilist-sync.get.ts
+++ b/server/api/cron/anilist-sync.get.ts
@@ -1,8 +1,18 @@
-import { createError, defineEventHandler } from "h3";
+import { createError, defineEventHandler, getHeader } from "h3";
 import { runHourlyAniListSync } from "../../../services/anilist/hourlySync.service";
 import { prisma } from "../../../utils/prisma";
 
-export default defineEventHandler(async () => {
+export default defineEventHandler(async (event) => {
+  const cronSecret = process.env.CRON_SECRET;
+  if (cronSecret) {
+    const authHeader = getHeader(event, "authorization");
+    if (authHeader !== `Bearer ${cronSecret}`) {
+      throw createError({ statusCode: 401, statusMessage: "Unauthorized" });
+    }
+  } else {
+    console.warn("[cron] CRON_SECRET is not set – endpoint is unprotected");
+  }
+
   const running = await prisma.syncState.findUnique({
     where: { key: "anilist_sync_running" },
   });

--- a/server/api/private/anilist-airing-calendar.get.ts
+++ b/server/api/private/anilist-airing-calendar.get.ts
@@ -117,6 +117,10 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: "Missing query param: user" });
   }
 
+  if (!/^[a-zA-Z0-9_-]{1,30}$/.test(user)) {
+    throw createError({ statusCode: 400, statusMessage: "Invalid username format" });
+  }
+
   const storage = useStorage("cache");
   const cacheKey = `anilist:airing-calendar:${user.toLowerCase()}:${includePlanningNotYetReleased ? "planning" : "current"}`;
   const cached = await storage.getItem<{

--- a/server/api/private/anilist-user-list.get.ts
+++ b/server/api/private/anilist-user-list.get.ts
@@ -75,7 +75,12 @@ async function aniFetch(
   }
 
   if (!res.ok) {
-    throw createError({ statusCode: res.status, statusMessage: await res.text() });
+    const rawText = await res.text();
+    console.error(`[AniList] API error ${res.status}:`, rawText);
+    throw createError({
+      statusCode: res.status >= 500 ? 503 : res.status,
+      statusMessage: "External service error",
+    });
   }
 
   return res.json();
@@ -87,6 +92,10 @@ export default defineEventHandler(async (event) => {
 
   if (!user) {
     throw createError({ statusCode: 400, statusMessage: "Missing query param: user" });
+  }
+
+  if (!/^[a-zA-Z0-9_-]{1,30}$/.test(user)) {
+    throw createError({ statusCode: 400, statusMessage: "Invalid username format" });
   }
 
   await sleep(300);

--- a/server/api/private/recommendation.get.ts
+++ b/server/api/private/recommendation.get.ts
@@ -148,6 +148,10 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: "Missing user" });
   }
 
+  if (!/^[a-zA-Z0-9_-]{1,30}$/.test(user)) {
+    throw createError({ statusCode: 400, statusMessage: "Invalid username format" });
+  }
+
   const filterSeason =
     typeof q.season === "string" ? q.season.toUpperCase() : null;
 

--- a/server/api/private/test-anilist-sync.post.ts
+++ b/server/api/private/test-anilist-sync.post.ts
@@ -1,6 +1,10 @@
-import { defineEventHandler } from "h3";
+import { createError, defineEventHandler } from "h3";
 import { runHourlyAniListSync } from "../../../services/anilist/hourlySync.service";
 
 export default defineEventHandler(async () => {
+  if (process.env.NODE_ENV !== "development") {
+    throw createError({ statusCode: 404, statusMessage: "Not Found" });
+  }
+
   return runHourlyAniListSync();
 });

--- a/services/anilist/syncAnime.ts
+++ b/services/anilist/syncAnime.ts
@@ -92,7 +92,7 @@ type FullAnimeResponse = {
 
 function hashAnime(m: FullAnimeResponse["Media"]) {
   return crypto
-    .createHash("sha1")
+    .createHash("sha256")
     .update(
       JSON.stringify({
         en: m.title.english,

--- a/tests/api.private-test-anilist-sync.test.ts
+++ b/tests/api.private-test-anilist-sync.test.ts
@@ -7,10 +7,17 @@ vi.mock("../services/anilist/hourlySync.service", () => ({
 }))
 
 describe("api/private/test-anilist-sync.post", () => {
+  const originalNodeEnv = process.env.NODE_ENV
+
   beforeEach(() => {
     vi.resetModules()
     ;(globalThis as any).defineEventHandler = (handler: any) => handler
     runHourlyAniListSyncMock.mockClear()
+    process.env.NODE_ENV = "development"
+  })
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv
   })
 
   it("delegates to runHourlyAniListSync", async () => {
@@ -19,5 +26,11 @@ describe("api/private/test-anilist-sync.post", () => {
 
     await expect(mod.default()).resolves.toEqual({ synced: 3 })
     expect(runHourlyAniListSyncMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("returns 404 outside development", async () => {
+    process.env.NODE_ENV = "production"
+    const mod = await import("../server/api/private/test-anilist-sync.post")
+    await expect(mod.default()).rejects.toMatchObject({ statusCode: 404 })
   })
 })


### PR DESCRIPTION
## Summary

- **Cron endpoint auth**: `anilist-sync.get.ts` checks a `CRON_SECRET` Bearer token when the env var is set; warns if unset.
- **Username validation**: Regex `/^[a-zA-Z0-9_-]{1,30}/` applied on all endpoints accepting a `user` query param (user-list, recommendation, airing-calendar).
- **Error sanitization**: External AniList API errors no longer forwarded to clients verbatim; logged server-side only, returning a generic 503 message.
- **SHA256 instead of SHA1**: `syncAnime.ts` hash function upgraded.
- **Test endpoint dev-only**: `test-anilist-sync.post.ts` returns 404 outside `development` NODE_ENV.

## Notes
> This branch modifies `anilist-sync.get.ts` and `anilist-user-list.get.ts` — same files touched by `fix/backend-reliability` and `fix/minor-quality`. Merge order matters; resolve conflicts when stacking.

## Test plan
- [ ] Run `vitest`
- [ ] Verify cron endpoint returns 401 without correct Bearer token
- [ ] Verify invalid usernames return 400