### PR TITLE
Fix frontend quality: dedup ECharts, use composable, error logging, input validation

### DIFF
--- a/app/pages/calendar.vue
+++ b/app/pages/calendar.vue
@@ -24,13 +24,7 @@ type CalendarDay = {
 
 const { t, locale } = useLocale();
 
-const usernameCookie = useCookie<string>("anilist-user", { default: () => "" });
-const username = computed({
-  get: () => usernameCookie.value ?? "",
-  set: (val: string) => {
-    usernameCookie.value = val.trim();
-  },
-});
+const username = useAnilistUser();
 
 const loading = ref(false);
 const error = ref<string | null>(null);
@@ -91,6 +85,12 @@ async function loadAnime() {
       return;
     }
 
+    if (!/^[a-zA-Z0-9_-]{1,30}$/.test(currentUser)) {
+      error.value = "Invalid username format";
+      loading.value = false;
+      return;
+    }
+
     const res = await api.get("/api/private/anilist-airing-calendar", {
       params: {
         user: currentUser,
@@ -117,7 +117,8 @@ async function loadAnime() {
       }),
     );
     lastLoadedUser.value = currentUser;
-  } catch {
+  } catch (e) {
+    console.error("[Calendar]", e);
     error.value = `${t("common.errorPrefix")}: ${t("calendar.loadError")}`;
   } finally {
     loading.value = false;

--- a/app/pages/combine.vue
+++ b/app/pages/combine.vue
@@ -67,7 +67,8 @@ async function loadAnime() {
       params: { user: username.value },
     });
     entries.value = normalizeAnilist(res.data.data.MediaListCollection.lists);
-  } catch {
+  } catch (e) {
+    console.error("[Combine]", e);
     error.value = `${t("common.errorPrefix")}: ${t("combine.loadError")}`;
   } finally {
     loading.value = false;

--- a/app/pages/compare.vue
+++ b/app/pages/compare.vue
@@ -13,7 +13,7 @@ import type {
 const { t } = useLocale();
 const { theme } = useTheme();
 
-const anilistUser = useCookie<string>("anilist-user", { default: () => "" });
+const anilistUser = useAnilistUser();
 
 type SeenFilter = "all" | "allUsers" | "noneUsers";
 type FilterState = "include" | "exclude";
@@ -81,6 +81,11 @@ async function addUser() {
   const name = userInput.value.trim();
   if (!name || users.value.includes(name)) return;
 
+  if (!/^[a-zA-Z0-9_-]{1,30}$/.test(name)) {
+    error.value = "Invalid username format";
+    return;
+  }
+
   users.value.push(name);
   userInput.value = "";
 
@@ -102,7 +107,8 @@ async function loadSingleUser(username: string) {
     });
 
     entriesByUser.value[username] = normalizeAnilist(res.data.data.MediaListCollection.lists);
-  } catch {
+  } catch (e) {
+    console.error("[Compare]", e);
     error.value = `${t("common.errorPrefix")}: ${t("compare.loadError")}`;
   } finally {
     loading.value = false;

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -10,28 +10,13 @@ import { TooltipComponent, LegendComponent, GridComponent, VisualMapComponent } 
 import VChart from "vue-echarts";
 
 use([CanvasRenderer, PieChart, LineChart, BarChart, ScatterChart, TooltipComponent, LegendComponent, GridComponent, VisualMapComponent]);
-use([
-  CanvasRenderer,
-  PieChart,
-  LineChart,
-  BarChart,
-  TooltipComponent,
-  LegendComponent,
-  GridComponent,
-]);
 
 type MetricMode = "titles" | "hours" | "score";
 
 definePageMeta({ title: "Dashboard", middleware: "auth" });
 const { t } = useLocale();
 
-const usernameCookie = useCookie<string>("anilist-user", { default: () => "" });
-const username = computed({
-  get: () => usernameCookie.value ?? "",
-  set: (val: string) => {
-    usernameCookie.value = val.trim();
-  },
-});
+const username = useAnilistUser();
 
 const loading = ref(false);
 const error = ref<string | null>(null);
@@ -97,6 +82,12 @@ async function loadAnime() {
       return;
     }
 
+    if (!/^[a-zA-Z0-9_-]{1,30}$/.test(currentUser)) {
+      error.value = "Invalid username format";
+      loading.value = false;
+      return;
+    }
+
     const res = await api.post("/api/private/anilist", null, {
       params: { user: currentUser },
     });
@@ -115,7 +106,8 @@ async function loadAnime() {
         : null,
     };
     lastLoadedUser.value = currentUser;
-  } catch {
+  } catch (e) {
+    console.error("[Dashboard]", e);
     error.value = `${t("common.errorPrefix")}: ${t("dashboard.loadError")}`;
     anilistStats.value = { episodesWatched: null, minutesWatched: null };
   } finally {
@@ -472,7 +464,8 @@ async function loadAtlasCatalog() {
   try {
     const res = await api.get<{ total: number; items: AtlasCatalogApiItem[] }>("/api/private/atlas-catalog");
     atlasCatalogItems.value = res.data.items ?? [];
-  } catch {
+  } catch (e) {
+    console.error("[Dashboard]", e);
     atlasCatalogError.value = `${t("common.errorPrefix")}: ${t("dashboard.atlasCatalogLoadError")}`;
   } finally {
     atlasCatalogLoading.value = false;

--- a/app/pages/genres.vue
+++ b/app/pages/genres.vue
@@ -47,7 +47,8 @@ async function loadAnime() {
       params: { user: username.value },
     });
     entries.value = normalizeAnilist(res.data.data.MediaListCollection.lists);
-  } catch {
+  } catch (e) {
+    console.error("[Genres]", e);
     error.value = `${t("common.errorPrefix")}: ${t("genres.loadError")}`;
   } finally {
     loading.value = false;

--- a/app/pages/history.vue
+++ b/app/pages/history.vue
@@ -123,7 +123,8 @@ async function loadHistory() {
     })
 
     results.value = [...(res ?? [])].sort((a, b) => completedKey(b) - completedKey(a))
-  } catch {
+  } catch (e) {
+    console.error("[History]", e)
     error.value = `${t("common.errorPrefix")}: ${t("history.loadError")}`
   } finally {
     loading.value = false

--- a/app/pages/recommendation.vue
+++ b/app/pages/recommendation.vue
@@ -120,7 +120,8 @@ async function loadRecommendations() {
     const res = await api.get<ApiRecommendationResponse>("/api/private/recommendation", { params });
     items.value = res.data.items;
     expandedTagCards.value = {};
-  } catch {
+  } catch (e) {
+    console.error("[Recommendation]", e);
     error.value = `${t("common.errorPrefix")}: ${t("recommendation.loadError")}`;
   } finally {
     loading.value = false;

--- a/app/pages/relations.vue
+++ b/app/pages/relations.vue
@@ -79,7 +79,8 @@ async function loadRelations() {
         })),
       })),
     }));
-  } catch {
+  } catch (e) {
+    console.error("[Relations]", e);
     error.value = `${t("common.errorPrefix")}: ${t("relations.loadError")}`;
   } finally {
     loading.value = false;

--- a/app/pages/tags.vue
+++ b/app/pages/tags.vue
@@ -46,7 +46,8 @@ async function loadAnime() {
       params: { user: username.value },
     });
     entries.value = normalizeAnilist(res.data.data.MediaListCollection.lists);
-  } catch {
+  } catch (e) {
+    console.error("[Tags]", e);
     error.value = `${t("common.errorPrefix")}: ${t("tags.loadError")}`;
   } finally {
     loading.value = false;


### PR DESCRIPTION
## Summary

- **Remove duplicate ECharts `use()` calls**: `dashboard.vue` had the same components registered twice; the duplicate block is removed.
- **Use `useAnilistUser()` composable**: `calendar.vue`, `compare.vue`, `dashboard.vue` replaced inline `useCookie` + `computed` with the shared composable for consistency.
- **Username validation on frontend**: Pages validate username format before sending requests (same regex as backend: `/^[a-zA-Z0-9_-]{1,30}/`).
- **Error logging in catch blocks**: All empty `catch {}` blocks across pages now log the error with a component prefix (e.g. `[Dashboard]`) for easier debugging.

## Notes
> This branch modifies `dashboard.vue` — same file touched by `fix/minor-quality`. Merge order matters.

## Test plan
- [ ] Smoke-test dashboard, calendar, compare pages in browser
- [ ] Verify duplicate ECharts registration is gone (check browser DevTools warning)
- [ ] Verify invalid username shows validation error before any API call