### PR TITLE
Minor quality: health check DB ping, null safety, magic numbers, auth logging

### DIFF
--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -1140,7 +1140,8 @@ const episodeDist = computed(() => {
     const ep = e.episodes ?? null;
     const bucket =
       episodeBins.find((b) => b.match(ep))?.label ?? t("common.unknown");
-    const cur = map.get(bucket)!;
+    const cur = map.get(bucket);
+    if (!cur) continue;
     cur.titles += 1;
     cur.hours += ((e.progress ?? 0) * (e.duration ?? 20)) / 60;
     if (Number(e.score || 0) > 0) {
@@ -1150,9 +1151,11 @@ const episodeDist = computed(() => {
   }
 
   const labels = episodeBins.map((b) => b.label);
-  const values = labels.map((l) =>
-    computeMetricValue(map.get(l)!, episodeMetric.value),
-  );
+  const values = labels.map((l) => {
+    const bucket = map.get(l);
+    if (!bucket) return 0;
+    return computeMetricValue(bucket, episodeMetric.value);
+  });
   return { labels, values };
 });
 

--- a/server/api/private/anilist-user-list.get.ts
+++ b/server/api/private/anilist-user-list.get.ts
@@ -47,6 +47,8 @@ function normalizeStatusLists(
   }));
 }
 
+const ANILIST_REQUEST_DELAY_MS = 300;
+
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 async function aniFetch(
@@ -98,7 +100,7 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: "Invalid username format" });
   }
 
-  await sleep(300);
+  await sleep(ANILIST_REQUEST_DELAY_MS);
 
   const res = await aniFetch(USER_LIST_QUERY, { user });
   const lists = normalizeStatusLists(res);

--- a/server/api/public/health.get.ts
+++ b/server/api/public/health.get.ts
@@ -1,7 +1,20 @@
-export default defineEventHandler(() => {
-  const now = new Date().toISOString();
+import { prisma } from "../../../utils/prisma";
+
+export default defineEventHandler(async (_event) => {
+  const start = Date.now();
+  let dbStatus: "ok" | "error" = "ok";
+
+  try {
+    // simple lightweight query to verify DB is reachable
+    await prisma.anime.findFirst({ select: { id: true } });
+  } catch {
+    dbStatus = "error";
+  }
+
   return {
-    ok: true,
-    time: now,
+    ok: dbStatus === "ok",
+    time: new Date().toISOString(),
+    latencyMs: Date.now() - start,
+    database: dbStatus,
   };
 });

--- a/server/middleware/private-auth.ts
+++ b/server/middleware/private-auth.ts
@@ -47,6 +47,11 @@ export default defineEventHandler(async (event) => {
 
   const token = getCookie(event, "anilist_token")
   if (!token) {
+    console.warn("[auth] rejected request:", {
+      url: event.node.req.url,
+      reason: "no_token",
+      timestamp: new Date().toISOString(),
+    })
     throw createError({
       statusCode: 401,
       statusMessage: "Unauthorized",
@@ -57,6 +62,11 @@ export default defineEventHandler(async (event) => {
     const isValid = await verifyAniListToken(token)
 
     if (!isValid) {
+      console.warn("[auth] rejected request:", {
+        url: event.node.req.url,
+        reason: "invalid_token",
+        timestamp: new Date().toISOString(),
+      })
       deleteCookie(event, "anilist_token", { path: "/" })
       throw createError({
         statusCode: 401,

--- a/services/anilist/syncAnime.ts
+++ b/services/anilist/syncAnime.ts
@@ -2,6 +2,8 @@ import { prisma } from "../../utils/prisma";
 import { anilistRequest } from "./anilistClient";
 import crypto from "crypto";
 
+const ANILIST_REQUEST_DELAY_MS = 300;
+
 const QUERY = `
 query FullAnime($id: Int!) {
   Media(id: $id, type: ANIME) {
@@ -258,5 +260,5 @@ export async function syncAnime(anilistId: number) {
   }
 
   // Mini Rate-Limit Guard
-  await new Promise((r) => setTimeout(r, 300));
+  await new Promise((r) => setTimeout(r, ANILIST_REQUEST_DELAY_MS));
 }

--- a/tests/api.public-health.test.ts
+++ b/tests/api.public-health.test.ts
@@ -1,16 +1,38 @@
-import { beforeEach, describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("../utils/prisma", () => ({
+  prisma: {
+    anime: {
+      findFirst: vi.fn(async () => ({ id: 1 })),
+    },
+  },
+}))
 
 describe("api/public/health.get", () => {
   beforeEach(() => {
+    vi.resetModules()
     ;(globalThis as any).defineEventHandler = (handler: any) => handler
   })
 
-  it("returns ok and an ISO timestamp", async () => {
+  it("returns ok and an ISO timestamp when DB is reachable", async () => {
     const mod = await import("../server/api/public/health.get")
     const out = await mod.default()
 
     expect(out.ok).toBe(true)
+    expect(out.database).toBe("ok")
     expect(typeof out.time).toBe("string")
     expect(new Date(out.time).toString()).not.toBe("Invalid Date")
+    expect(typeof out.latencyMs).toBe("number")
+  })
+
+  it("returns ok=false when DB is unreachable", async () => {
+    const { prisma } = await import("../utils/prisma")
+    vi.mocked(prisma.anime.findFirst).mockRejectedValueOnce(new Error("connection refused"))
+
+    const mod = await import("../server/api/public/health.get")
+    const out = await mod.default()
+
+    expect(out.ok).toBe(false)
+    expect(out.database).toBe("error")
   })
 })


### PR DESCRIPTION
## Summary

- **Health endpoint DB check**: `health.get.ts` now pings the DB with a lightweight query and returns `{ ok, database, latencyMs }`, making it a real liveness probe instead of a static response.
- **Null safety in `episodeDist`**: Removed non-null assertions (`!`) in `dashboard.vue` that could crash at runtime if a bucket label was missing; replaced with safe guards.
- **Named constants for magic numbers**: The 300ms rate-limit delay is now `ANILIST_REQUEST_DELAY_MS` in both `syncAnime.ts` and `anilist-user-list.get.ts`.
- **Auth rejection logging**: `private-auth.ts` logs URL, rejection reason, and timestamp when bouncing unauthenticated requests.

## Notes
> This branch modifies `dashboard.vue` and `anilist-user-list.get.ts` — same files touched by `fix/frontend-quality` and `fix/backend-security`. Merge order matters.

## Test plan
- [ ] Run `vitest` (health test now includes a DB-down scenario)
- [ ] Verify `/api/public/health` returns `database` and `latencyMs` fields
- [ ] Verify episode distribution chart renders without crashes