### PR TITLE
Fix #11: Configurable minimum tag percentage threshold

### DIFF
--- a/app/i18n/translations.ts
+++ b/app/i18n/translations.ts
@@ -208,6 +208,8 @@ export const translations = {
       toggleTitleMode: "Toggle title order",
       upcomingHint: "Show not-yet-released anime",
       matchScore: "Match Score",
+      minTagRankLabel: "Min. Tag Percentage",
+      minTagRankHint: "Only consider tags above this AniList percentage threshold",
     },
     compare: {
       title: "Compare Users",
@@ -438,6 +440,8 @@ export const translations = {
       toggleTitleMode: "Titelreihenfolge umschalten",
       upcomingHint: "Noch nicht erschienene Anime anzeigen",
       matchScore: "Match Score",
+      minTagRankLabel: "Min. Tag-Prozentsatz",
+      minTagRankHint: "Nur Tags ab diesem AniList-Prozentschwellenwert berücksichtigen",
     },
     compare: {
       title: "User vergleichen",

--- a/app/pages/recommendation.vue
+++ b/app/pages/recommendation.vue
@@ -34,6 +34,7 @@ const seasonYearMax = ref<number | null>(CURRENT_YEAR);
 const episodesMin = ref<number | null>(null);
 const episodesMax = ref<number | null>(null);
 const averageScoreMin = ref<number | null>(null);
+const minTagRank = ref<number>(0);
 
 const genreStates = ref<Record<string, FilterState>>({});
 const tagStates = ref<Record<string, FilterState>>({});
@@ -98,6 +99,7 @@ async function loadRecommendations() {
     if (episodesMin.value) params.episodesMin = episodesMin.value;
     if (episodesMax.value) params.episodesMax = episodesMax.value;
     if (averageScoreMin.value) params.averageScoreMin = averageScoreMin.value;
+    if (minTagRank.value > 0) params.minTagRank = minTagRank.value;
 
     const includeGenres = Object.entries(genreStates.value)
       .filter(([, state]) => state === "include")
@@ -146,7 +148,7 @@ watch([activeTab, layoutMode], () => {
   currentPage.value = 1;
 });
 watch(
-  [tagSearch, selectedTags, genreStates, filterSeason, seasonYearMin, seasonYearMax, episodesMin, episodesMax, averageScoreMin, includeUpcoming],
+  [tagSearch, selectedTags, genreStates, filterSeason, seasonYearMin, seasonYearMax, episodesMin, episodesMax, averageScoreMin, includeUpcoming, minTagRank],
   () => {
     filterTagCurrentPage.value = 1;
     currentPage.value = 1;
@@ -271,6 +273,28 @@ function hiddenGridTagCount(item: ApiRecommendationItem) {
         <input v-model.number="episodesMax" type="number" :placeholder="t('common.maxEpisodes')" class="ui-input" />
 
         <input v-model.number="averageScoreMin" type="number" :placeholder="t('common.minAvgScore')" class="ui-input" />
+      </div>
+
+      <div class="flex flex-col gap-1">
+        <label class="text-xs text-zinc-400 font-medium">
+          {{ t("recommendation.minTagRankLabel") }}: <span class="text-zinc-200">{{ minTagRank }}%</span>
+          <span class="ml-2 text-zinc-500">{{ t("recommendation.minTagRankHint") }}</span>
+        </label>
+        <input
+          v-model.number="minTagRank"
+          type="range"
+          min="0"
+          max="85"
+          step="5"
+          class="w-full accent-indigo-500"
+          @change="loadRecommendations"
+        />
+        <div class="flex justify-between text-[10px] text-zinc-600">
+          <span>0%</span>
+          <span>25%</span>
+          <span>50%</span>
+          <span>85%</span>
+        </div>
       </div>
 
       <div class="flex items-center gap-2">

--- a/server/api/private/recommendation.get.ts
+++ b/server/api/private/recommendation.get.ts
@@ -161,6 +161,8 @@ export default defineEventHandler(async (event) => {
   const episodesMax = parseNumber(q.episodesMax);
   const avgScoreMin = parseNumber(q.averageScoreMin);
   const avgScoreMax = parseNumber(q.averageScoreMax);
+  const minTagRankRaw = parseNumber(q.minTagRank);
+  const minTagRank = minTagRankRaw !== null ? Math.max(0, Math.min(100, Math.round(minTagRankRaw))) : 0;
 
   const includeGenres = parseList(q.genres) ?? [];
   const excludeGenres = parseList(q.excludeGenres) ?? [];
@@ -323,6 +325,7 @@ export default defineEventHandler(async (event) => {
 
   for (const tag of metadata.tags) {
     if (!metadataIdSet.has(tag.animeId)) continue;
+    if (minTagRank > 0 && (tag.rank === null || tag.rank < minTagRank)) continue;
     const compact = {
       tagId: tag.tagId,
       name: tag.name,


### PR DESCRIPTION
Closes #11

## Summary
- Adds `minTagRank` query parameter to `/api/private/recommendation` (0–100, default 0)
- Tags with `rank < minTagRank` (or `rank === null`) are excluded before scoring and taste-profile building
- Adds a range slider (0–85%, step 5%) on the Recommendation page so users can control the threshold
- Adds EN/DE i18n strings for the new control

## Test plan
- [ ] Load recommendations with minTagRank = 0 (default) → same results as before
- [ ] Set slider to 60% → verify only tags with AniList rank ≥ 60 are in the result tags list
- [ ] Verify API rejects values < 0 or > 100 gracefully (clamped server-side)
- [ ] Check EN and DE labels display correctly