### PR TITLE
Release: Auth overhaul, backend hardening, security fixes, frontend quality & new features

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,106 @@
+<!-- Use this file to provide workspace-specific custom instructions to Copilot. For more details, visit https://code.visualstudio.com/docs/copilot/copilot-customization#_use-a-githubcopilotinstructionsmd-file -->
+- [ ] Verify that the copilot-instructions.md file in the .github directory is created.
+
+- [ ] Clarify Project Requirements
+	<!-- Ask for project type, language, and frameworks if not specified. Skip if already provided. -->
+
+- [ ] Scaffold the Project
+	<!--
+	Ensure that the previous step has been marked as completed.
+	Call project setup tool with projectType parameter.
+	Run scaffolding command to create project files and folders.
+	Use '.' as the working directory.
+	If no appropriate projectType is available, search documentation using available tools.
+	Otherwise, create the project structure manually using available file creation tools.
+	-->
+
+- [ ] Customize the Project
+	<!--
+	Verify that all previous steps have been completed successfully and you have marked the step as completed.
+	Develop a plan to modify codebase according to user requirements.
+	Apply modifications using appropriate tools and user-provided references.
+	Skip this step for "Hello World" projects.
+	-->
+
+- [ ] Install Required Extensions
+	<!-- ONLY install extensions provided mentioned in the get_project_setup_info. Skip this step otherwise and mark as completed. -->
+
+- [ ] Compile the Project
+	<!--
+	Verify that all previous steps have been completed.
+	Install any missing dependencies.
+	Run diagnostics and resolve any issues.
+	Check for markdown files in project folder for relevant instructions on how to do this.
+	-->
+
+- [ ] Create and Run Task
+	<!--
+	Verify that all previous steps have been completed.
+	Check https://code.visualstudio.com/docs/debugtest/tasks to determine if the project needs a task. If so, use the create_and_run_task to create and launch a task based on package.json, README.md, and project structure.
+	Skip this step otherwise.
+	 -->
+
+- [ ] Launch the Project
+	<!--
+	Verify that all previous steps have been completed.
+	Prompt user for debug mode, launch only if confirmed.
+	 -->
+
+- [ ] Ensure Documentation is Complete
+	<!--
+	Verify that all previous steps have been completed.
+	Verify that README.md and the copilot-instructions.md file in the .github directory exists and contains current project information.
+	Clean up the copilot-instructions.md file in the .github directory by removing all HTML comments.
+	 -->
+
+<!--
+## Execution Guidelines
+PROGRESS TRACKING:
+- If any tools are available to manage the above todo list, use it to track progress through this checklist.
+- After completing each step, mark it complete and add a summary.
+- Read current todo list status before starting each new step.
+
+COMMUNICATION RULES:
+- Avoid verbose explanations or printing full command outputs.
+- If a step is skipped, state that briefly (e.g. "No extensions needed").
+- Do not explain project structure unless asked.
+- Keep explanations concise and focused.
+
+DEVELOPMENT RULES:
+- Use '.' as the working directory unless user specifies otherwise.
+- Avoid adding media or external links unless explicitly requested.
+- Use placeholders only with a note that they should be replaced.
+- Use VS Code API tool only for VS Code extension projects.
+- Once the project is created, it is already opened in Visual Studio Code—do not suggest commands to open this project in Visual Studio again.
+- If the project setup information has additional rules, follow them strictly.
+
+FOLDER CREATION RULES:
+- Always use the current directory as the project root.
+- If you are running any terminal commands, use the '.' argument to ensure that the current working directory is used ALWAYS.
+- Do not create a new folder unless the user explicitly requests it besides a .vscode folder for a tasks.json file.
+- If any of the scaffolding commands mention that the folder name is not correct, let the user know to create a new folder with the correct name and then reopen it again in vscode.
+
+EXTENSION INSTALLATION RULES:
+- Only install extension specified by the get_project_setup_info tool. DO NOT INSTALL any other extensions.
+
+PROJECT CONTENT RULES:
+- If the user has not specified project details, assume they want a "Hello World" project as a starting point.
+- Avoid adding links of any type (URLs, files, folders, etc.) or integrations that are not explicitly required.
+- Avoid generating images, videos, or any other media files unless explicitly requested.
+- If you need to use any media assets as placeholders, let the user know that these are placeholders and should be replaced with the actual assets later.
+- Ensure all generated components serve a clear purpose within the user's requested workflow.
+- If a feature is assumed but not confirmed, prompt the user for clarification before including it.
+- If you are working on a VS Code extension, use the VS Code API tool with a query to find relevant VS Code API references and samples related to that query.
+
+TASK COMPLETION RULES:
+- Your task is complete when:
+  - Project is successfully scaffolded and compiled without errors
+  - copilot-instructions.md file in the .github directory exists in the project
+  - README.md file exists and is up to date
+  - User is provided with clear instructions to debug/launch the project
+
+Before starting a new task in the above plan, update progress in the plan.
+-->
+- Work through each checklist item systematically.
+- Keep communication concise and focused.
+- Follow development best practices.

--- a/app/i18n/translations.ts
+++ b/app/i18n/translations.ts
@@ -119,6 +119,9 @@ export const translations = {
       china: "China",
       upcomingIncluded: "Include upcoming",
       upcomingHidden: "Hide upcoming",
+      milestones: "Milestones",
+      milestonesAnimeOrdinalSuffix: "th Anime",
+      milestonesWatchDays: "Days Watched",
     },
     index: {
       badge: "AniList-inspired analytics workspace",
@@ -351,6 +354,9 @@ export const translations = {
       china: "China",
       upcomingIncluded: "Upcoming einbeziehen",
       upcomingHidden: "Upcoming ausblenden",
+      milestones: "Meilensteine",
+      milestonesAnimeOrdinalSuffix: ". Anime",
+      milestonesWatchDays: "Tage geschaut",
     },
     index: {
       badge: "AniList-inspiriertes Analytics Workspace",

--- a/app/i18n/translations.ts
+++ b/app/i18n/translations.ts
@@ -211,6 +211,8 @@ export const translations = {
       toggleTitleMode: "Toggle title order",
       upcomingHint: "Show not-yet-released anime",
       matchScore: "Match Score",
+      minTagRankLabel: "Min. Tag Percentage",
+      minTagRankHint: "Only consider tags above this AniList percentage threshold",
     },
     compare: {
       title: "Compare Users",
@@ -444,6 +446,8 @@ export const translations = {
       toggleTitleMode: "Titelreihenfolge umschalten",
       upcomingHint: "Noch nicht erschienene Anime anzeigen",
       matchScore: "Match Score",
+      minTagRankLabel: "Min. Tag-Prozentsatz",
+      minTagRankHint: "Nur Tags ab diesem AniList-Prozentschwellenwert berücksichtigen",
     },
     compare: {
       title: "User vergleichen",

--- a/app/pages/calendar.vue
+++ b/app/pages/calendar.vue
@@ -24,13 +24,7 @@ type CalendarDay = {
 
 const { t, locale } = useLocale();
 
-const usernameCookie = useCookie<string>("anilist-user", { default: () => "" });
-const username = computed({
-  get: () => usernameCookie.value ?? "",
-  set: (val: string) => {
-    usernameCookie.value = val.trim();
-  },
-});
+const username = useAnilistUser();
 
 const loading = ref(false);
 const error = ref<string | null>(null);
@@ -91,6 +85,12 @@ async function loadAnime() {
       return;
     }
 
+    if (!/^[a-zA-Z0-9_-]{1,30}$/.test(currentUser)) {
+      error.value = "Invalid username format";
+      loading.value = false;
+      return;
+    }
+
     const res = await api.get("/api/private/anilist-airing-calendar", {
       params: {
         user: currentUser,
@@ -117,7 +117,8 @@ async function loadAnime() {
       }),
     );
     lastLoadedUser.value = currentUser;
-  } catch {
+  } catch (e) {
+    console.error("[Calendar]", e);
     error.value = `${t("common.errorPrefix")}: ${t("calendar.loadError")}`;
   } finally {
     loading.value = false;

--- a/app/pages/combine.vue
+++ b/app/pages/combine.vue
@@ -67,7 +67,8 @@ async function loadAnime() {
       params: { user: username.value },
     });
     entries.value = normalizeAnilist(res.data.data.MediaListCollection.lists);
-  } catch {
+  } catch (e) {
+    console.error("[Combine]", e);
     error.value = `${t("common.errorPrefix")}: ${t("combine.loadError")}`;
   } finally {
     loading.value = false;

--- a/app/pages/compare.vue
+++ b/app/pages/compare.vue
@@ -13,7 +13,7 @@ import type {
 const { t } = useLocale();
 const { theme } = useTheme();
 
-const anilistUser = useCookie<string>("anilist-user", { default: () => "" });
+const anilistUser = useAnilistUser();
 
 type SeenFilter = "all" | "allUsers" | "noneUsers";
 type FilterState = "include" | "exclude";
@@ -81,6 +81,11 @@ async function addUser() {
   const name = userInput.value.trim();
   if (!name || users.value.includes(name)) return;
 
+  if (!/^[a-zA-Z0-9_-]{1,30}$/.test(name)) {
+    error.value = "Invalid username format";
+    return;
+  }
+
   users.value.push(name);
   userInput.value = "";
 
@@ -102,7 +107,8 @@ async function loadSingleUser(username: string) {
     });
 
     entriesByUser.value[username] = normalizeAnilist(res.data.data.MediaListCollection.lists);
-  } catch {
+  } catch (e) {
+    console.error("[Compare]", e);
     error.value = `${t("common.errorPrefix")}: ${t("compare.loadError")}`;
   } finally {
     loading.value = false;

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -185,6 +185,97 @@ const totalPlannedDays = computed(() => {
   return Number((plannedMinutes / 60 / 24).toFixed(1));
 });
 
+// ─── Milestones ──────────────────────────────────────────────────────────────
+
+interface Milestone {
+  kind: "anime" | "watchtime";
+  label: string;     // e.g. "100th Anime" | "50 Days Watched"
+  value: number;     // count or days
+  title: string | null;
+  date: string | null;
+}
+
+function fuzzyDateToTimestamp(fd: { year?: number | null; month?: number | null; day?: number | null } | null): number {
+  if (!fd?.year) return 0;
+  return Date.UTC(fd.year, Math.max((fd.month ?? 1) - 1, 0), Math.max(fd.day ?? 1, 1));
+}
+
+function formatFuzzyDate(fd: { year?: number | null; month?: number | null; day?: number | null } | null): string | null {
+  if (!fd?.year) return null;
+  const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+  const parts: string[] = [];
+  if (fd.day) parts.push(String(fd.day));
+  if (fd.month) parts.push(months[(fd.month ?? 1) - 1]);
+  parts.push(String(fd.year));
+  return parts.join(" ");
+}
+
+const ANIME_MILESTONE_INTERVALS = [1, 50, 100, 150, 200, 250, 300, 350, 400, 450, 500];
+const WATCHTIME_MILESTONE_DAYS = [10, 25, 50, 75, 100, 150, 200, 250, 300];
+
+const milestones = computed<Milestone[]>(() => {
+  const result: Milestone[] = [];
+
+  // Sort completed entries by completedAt date ascending
+  const sorted = [...completedEntries.value]
+    .filter((e) => fuzzyDateToTimestamp(e.completedAt) > 0)
+    .sort((a, b) => fuzzyDateToTimestamp(a.completedAt) - fuzzyDateToTimestamp(b.completedAt));
+
+  if (sorted.length === 0) return result;
+
+  // Anime count milestones
+  for (const n of ANIME_MILESTONE_INTERVALS) {
+    if (n > sorted.length) break;
+    const entry = sorted[n - 1];
+    const titleEn = entry.title?.english?.trim() || null;
+    const titleRo = entry.title?.romaji?.trim() || null;
+    result.push({
+      kind: "anime",
+      label: `${n}`,
+      value: n,
+      title: titleEn ?? titleRo,
+      date: formatFuzzyDate(entry.completedAt),
+    });
+  }
+
+  // Watch-time milestones: accumulate minutes up to each completedAt date
+  // Use per-entry estimate: progress * duration
+  let cumulativeMinutes = 0;
+  let nextDayMilestoneIndex = 0;
+
+  for (const entry of sorted) {
+    const entryMinutes = (entry.progress ?? 0) * (entry.duration ?? 20);
+    cumulativeMinutes += entryMinutes;
+
+    while (
+      nextDayMilestoneIndex < WATCHTIME_MILESTONE_DAYS.length &&
+      cumulativeMinutes / 60 / 24 >= WATCHTIME_MILESTONE_DAYS[nextDayMilestoneIndex]
+    ) {
+      const days = WATCHTIME_MILESTONE_DAYS[nextDayMilestoneIndex];
+      // Only add if we have at least a rough date
+      if (fuzzyDateToTimestamp(entry.completedAt) > 0) {
+        result.push({
+          kind: "watchtime",
+          label: `${days}`,
+          value: days,
+          title: null,
+          date: formatFuzzyDate(entry.completedAt),
+        });
+      }
+      nextDayMilestoneIndex++;
+    }
+
+  }
+
+  // Sort milestones by kind (anime first), then by value ascending
+  result.sort((a, b) => {
+    if (a.kind !== b.kind) return a.kind === "anime" ? -1 : 1;
+    return a.value - b.value;
+  });
+
+  return result;
+});
+
 const scoredEntries = computed(() =>
   completedEntries.value.filter((e) => Number(e.score ?? 0) > 0),
 );
@@ -1758,6 +1849,25 @@ const countryPercentLabels = computed(() =>
           />
         </ClientOnly>
       </section>
+
+      <section v-if="milestones.length" class="dashboard-panel">
+        <h2 class="mb-4 text-xl font-semibold">{{ t("dashboard.milestones") }}</h2>
+        <div class="milestones-grid">
+          <div
+            v-for="m in milestones"
+            :key="`${m.kind}-${m.value}`"
+            class="milestone-card"
+            :class="m.kind === 'watchtime' ? 'milestone-card-time' : 'milestone-card-anime'"
+          >
+            <div class="milestone-badge">
+              <span v-if="m.kind === 'anime'">{{ m.value }}{{ t("dashboard.milestonesAnimeOrdinalSuffix") }}</span>
+              <span v-else>{{ m.value }} {{ t("dashboard.milestonesWatchDays") }}</span>
+            </div>
+            <div v-if="m.title" class="milestone-title">{{ m.title }}</div>
+            <div v-if="m.date" class="milestone-date">{{ m.date }}</div>
+          </div>
+        </div>
+      </section>
     </div>
   </div>
 </template>
@@ -2158,6 +2268,64 @@ const countryPercentLabels = computed(() =>
   .atlas-filter-ranges {
     grid-template-columns: 1fr;
   }
+}
+
+/* ─── Milestones ─────────────────────────────────────────────────────────── */
+.milestones-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 0.75rem;
+}
+
+.milestone-card {
+  border: 1px solid var(--border);
+  border-radius: 0.65rem;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.milestone-card-anime {
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.08), rgba(99, 102, 241, 0.03));
+  border-color: rgba(99, 102, 241, 0.25);
+}
+
+.milestone-card-time {
+  background: linear-gradient(135deg, rgba(16, 185, 129, 0.08), rgba(16, 185, 129, 0.03));
+  border-color: rgba(16, 185, 129, 0.25);
+}
+
+.milestone-badge {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+
+.milestone-card-anime .milestone-badge {
+  color: #818cf8;
+}
+
+.milestone-card-time .milestone-badge {
+  color: #34d399;
+}
+
+.milestone-title {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text);
+  line-height: 1.25;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.milestone-date {
+  font-size: 0.74rem;
+  color: var(--text-muted);
 }
 </style>
 

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -1140,7 +1140,8 @@ const episodeDist = computed(() => {
     const ep = e.episodes ?? null;
     const bucket =
       episodeBins.find((b) => b.match(ep))?.label ?? t("common.unknown");
-    const cur = map.get(bucket)!;
+    const cur = map.get(bucket);
+    if (!cur) continue;
     cur.titles += 1;
     cur.hours += ((e.progress ?? 0) * (e.duration ?? 20)) / 60;
     if (Number(e.score || 0) > 0) {
@@ -1150,9 +1151,11 @@ const episodeDist = computed(() => {
   }
 
   const labels = episodeBins.map((b) => b.label);
-  const values = labels.map((l) =>
-    computeMetricValue(map.get(l)!, episodeMetric.value),
-  );
+  const values = labels.map((l) => {
+    const bucket = map.get(l);
+    if (!bucket) return 0;
+    return computeMetricValue(bucket, episodeMetric.value);
+  });
   return { labels, values };
 });
 

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -10,28 +10,13 @@ import { TooltipComponent, LegendComponent, GridComponent, VisualMapComponent } 
 import VChart from "vue-echarts";
 
 use([CanvasRenderer, PieChart, LineChart, BarChart, ScatterChart, TooltipComponent, LegendComponent, GridComponent, VisualMapComponent]);
-use([
-  CanvasRenderer,
-  PieChart,
-  LineChart,
-  BarChart,
-  TooltipComponent,
-  LegendComponent,
-  GridComponent,
-]);
 
 type MetricMode = "titles" | "hours" | "score";
 
 definePageMeta({ title: "Dashboard", middleware: "auth" });
 const { t } = useLocale();
 
-const usernameCookie = useCookie<string>("anilist-user", { default: () => "" });
-const username = computed({
-  get: () => usernameCookie.value ?? "",
-  set: (val: string) => {
-    usernameCookie.value = val.trim();
-  },
-});
+const username = useAnilistUser();
 
 const loading = ref(false);
 const error = ref<string | null>(null);
@@ -97,6 +82,12 @@ async function loadAnime() {
       return;
     }
 
+    if (!/^[a-zA-Z0-9_-]{1,30}$/.test(currentUser)) {
+      error.value = "Invalid username format";
+      loading.value = false;
+      return;
+    }
+
     const res = await api.post("/api/private/anilist", null, {
       params: { user: currentUser },
     });
@@ -115,7 +106,8 @@ async function loadAnime() {
         : null,
     };
     lastLoadedUser.value = currentUser;
-  } catch {
+  } catch (e) {
+    console.error("[Dashboard]", e);
     error.value = `${t("common.errorPrefix")}: ${t("dashboard.loadError")}`;
     anilistStats.value = { episodesWatched: null, minutesWatched: null };
   } finally {
@@ -472,7 +464,8 @@ async function loadAtlasCatalog() {
   try {
     const res = await api.get<{ total: number; items: AtlasCatalogApiItem[] }>("/api/private/atlas-catalog");
     atlasCatalogItems.value = res.data.items ?? [];
-  } catch {
+  } catch (e) {
+    console.error("[Dashboard]", e);
     atlasCatalogError.value = `${t("common.errorPrefix")}: ${t("dashboard.atlasCatalogLoadError")}`;
   } finally {
     atlasCatalogLoading.value = false;

--- a/app/pages/genres.vue
+++ b/app/pages/genres.vue
@@ -47,7 +47,8 @@ async function loadAnime() {
       params: { user: username.value },
     });
     entries.value = normalizeAnilist(res.data.data.MediaListCollection.lists);
-  } catch {
+  } catch (e) {
+    console.error("[Genres]", e);
     error.value = `${t("common.errorPrefix")}: ${t("genres.loadError")}`;
   } finally {
     loading.value = false;

--- a/app/pages/history.vue
+++ b/app/pages/history.vue
@@ -123,7 +123,8 @@ async function loadHistory() {
     })
 
     results.value = [...(res ?? [])].sort((a, b) => completedKey(b) - completedKey(a))
-  } catch {
+  } catch (e) {
+    console.error("[History]", e)
     error.value = `${t("common.errorPrefix")}: ${t("history.loadError")}`
   } finally {
     loading.value = false

--- a/app/pages/recommendation.vue
+++ b/app/pages/recommendation.vue
@@ -34,6 +34,7 @@ const seasonYearMax = ref<number | null>(CURRENT_YEAR);
 const episodesMin = ref<number | null>(null);
 const episodesMax = ref<number | null>(null);
 const averageScoreMin = ref<number | null>(null);
+const minTagRank = ref<number>(0);
 
 const genreStates = ref<Record<string, FilterState>>({});
 const tagStates = ref<Record<string, FilterState>>({});
@@ -98,6 +99,7 @@ async function loadRecommendations() {
     if (episodesMin.value) params.episodesMin = episodesMin.value;
     if (episodesMax.value) params.episodesMax = episodesMax.value;
     if (averageScoreMin.value) params.averageScoreMin = averageScoreMin.value;
+    if (minTagRank.value > 0) params.minTagRank = minTagRank.value;
 
     const includeGenres = Object.entries(genreStates.value)
       .filter(([, state]) => state === "include")
@@ -146,7 +148,7 @@ watch([activeTab, layoutMode], () => {
   currentPage.value = 1;
 });
 watch(
-  [tagSearch, selectedTags, genreStates, filterSeason, seasonYearMin, seasonYearMax, episodesMin, episodesMax, averageScoreMin, includeUpcoming],
+  [tagSearch, selectedTags, genreStates, filterSeason, seasonYearMin, seasonYearMax, episodesMin, episodesMax, averageScoreMin, includeUpcoming, minTagRank],
   () => {
     filterTagCurrentPage.value = 1;
     currentPage.value = 1;
@@ -271,6 +273,28 @@ function hiddenGridTagCount(item: ApiRecommendationItem) {
         <input v-model.number="episodesMax" type="number" :placeholder="t('common.maxEpisodes')" class="ui-input" />
 
         <input v-model.number="averageScoreMin" type="number" :placeholder="t('common.minAvgScore')" class="ui-input" />
+      </div>
+
+      <div class="flex flex-col gap-1">
+        <label class="text-xs text-zinc-400 font-medium">
+          {{ t("recommendation.minTagRankLabel") }}: <span class="text-zinc-200">{{ minTagRank }}%</span>
+          <span class="ml-2 text-zinc-500">{{ t("recommendation.minTagRankHint") }}</span>
+        </label>
+        <input
+          v-model.number="minTagRank"
+          type="range"
+          min="0"
+          max="85"
+          step="5"
+          class="w-full accent-indigo-500"
+          @change="loadRecommendations"
+        />
+        <div class="flex justify-between text-[10px] text-zinc-600">
+          <span>0%</span>
+          <span>25%</span>
+          <span>50%</span>
+          <span>85%</span>
+        </div>
       </div>
 
       <div class="flex items-center gap-2">

--- a/app/pages/recommendation.vue
+++ b/app/pages/recommendation.vue
@@ -120,7 +120,8 @@ async function loadRecommendations() {
     const res = await api.get<ApiRecommendationResponse>("/api/private/recommendation", { params });
     items.value = res.data.items;
     expandedTagCards.value = {};
-  } catch {
+  } catch (e) {
+    console.error("[Recommendation]", e);
     error.value = `${t("common.errorPrefix")}: ${t("recommendation.loadError")}`;
   } finally {
     loading.value = false;

--- a/app/pages/relations.vue
+++ b/app/pages/relations.vue
@@ -79,7 +79,8 @@ async function loadRelations() {
         })),
       })),
     }));
-  } catch {
+  } catch (e) {
+    console.error("[Relations]", e);
     error.value = `${t("common.errorPrefix")}: ${t("relations.loadError")}`;
   } finally {
     loading.value = false;

--- a/app/pages/tags.vue
+++ b/app/pages/tags.vue
@@ -46,7 +46,8 @@ async function loadAnime() {
       params: { user: username.value },
     });
     entries.value = normalizeAnilist(res.data.data.MediaListCollection.lists);
-  } catch {
+  } catch (e) {
+    console.error("[Tags]", e);
     error.value = `${t("common.errorPrefix")}: ${t("tags.loadError")}`;
   } finally {
     loading.value = false;

--- a/server/api/auth/callback.get.ts
+++ b/server/api/auth/callback.get.ts
@@ -1,4 +1,5 @@
 import type { AniOAuthTokenResponse } from "../../types/api/auth"
+import { setAniListAuthCookies } from "../../utils/anilistAuth"
 
 export default defineEventHandler(async (event) => {
   const { code } = getQuery(event);
@@ -28,19 +29,7 @@ export default defineEventHandler(async (event) => {
       body: params.toString(),
     }
   );
-
-  const token = tokenRes.access_token;
-
-  if (!token) {
-    throw createError({ statusCode: 500, statusMessage: "No token received" });
-  }
-
-  setCookie(event, "anilist_token", token, {
-    httpOnly: true,
-    sameSite: "lax",
-    path: "/",
-    secure: process.env.NODE_ENV === "production",
-  });
+  setAniListAuthCookies(event, tokenRes);
 
   return sendRedirect(event, "/");
 });

--- a/server/api/auth/logout.post.ts
+++ b/server/api/auth/logout.post.ts
@@ -1,6 +1,6 @@
+import { clearAniListAuthCookies } from "../../utils/anilistAuth"
+
 export default defineEventHandler(async (event) => {
-  deleteCookie(event, "anilist_token", {
-    path: "/",
-  });
+  clearAniListAuthCookies(event)
   return sendRedirect(event, "/");
 });

--- a/server/api/auth/me.get.ts
+++ b/server/api/auth/me.get.ts
@@ -1,4 +1,5 @@
 import type { AniViewerNameResponse } from "../../types/api/auth"
+import { getAniListAccessToken } from "../../utils/anilistAuth"
 
 function getViewerName(response: AniViewerNameResponse): string | null {
   if (!response.data || !response.data.Viewer) return null;
@@ -7,7 +8,7 @@ function getViewerName(response: AniViewerNameResponse): string | null {
 }
 
 export default defineEventHandler(async (event) => {
-  const token = getCookie(event, "anilist_token");
+  const token = await getAniListAccessToken(event);
 
   if (!token) {
     return { user: null };

--- a/server/api/cron/anilist-sync.get.ts
+++ b/server/api/cron/anilist-sync.get.ts
@@ -1,8 +1,18 @@
-import { createError, defineEventHandler } from "h3";
+import { createError, defineEventHandler, getHeader } from "h3";
 import { runHourlyAniListSync } from "../../../services/anilist/hourlySync.service";
 import { prisma } from "../../../utils/prisma";
 
-export default defineEventHandler(async () => {
+export default defineEventHandler(async (event) => {
+  const cronSecret = process.env.CRON_SECRET;
+  if (cronSecret) {
+    const authHeader = getHeader(event, "authorization");
+    if (authHeader !== `Bearer ${cronSecret}`) {
+      throw createError({ statusCode: 401, statusMessage: "Unauthorized" });
+    }
+  } else {
+    console.warn("[cron] CRON_SECRET is not set – endpoint is unprotected");
+  }
+
   const running = await prisma.syncState.findUnique({
     where: { key: "anilist_sync_running" },
   });

--- a/server/api/cron/anilist-sync.get.ts
+++ b/server/api/cron/anilist-sync.get.ts
@@ -7,20 +7,11 @@ export default defineEventHandler(async () => {
     where: { key: "anilist_sync_running" },
   });
 
-  if (running?.value) {
-    const startedAt = Number(running.value);
-    const TWO_HOURS_MS = 2 * 60 * 60 * 1000;
-    if (!isNaN(startedAt) && Date.now() - startedAt < TWO_HOURS_MS) {
-      throw createError({
-        statusCode: 409,
-        statusMessage: "AniList sync already running",
-      });
-    }
-    if (!isNaN(startedAt)) {
-      console.warn(
-        `[AniList Sync] Stale lock detected (started ${new Date(startedAt).toISOString()}), proceeding anyway`
-      );
-    }
+  if (running?.value === "1") {
+    throw createError({
+      statusCode: 409,
+      statusMessage: "AniList sync already running",
+    });
   }
 
   return runHourlyAniListSync();

--- a/server/api/cron/anilist-sync.get.ts
+++ b/server/api/cron/anilist-sync.get.ts
@@ -7,11 +7,20 @@ export default defineEventHandler(async () => {
     where: { key: "anilist_sync_running" },
   });
 
-  if (running?.value === "1") {
-    throw createError({
-      statusCode: 409,
-      statusMessage: "AniList sync already running",
-    });
+  if (running?.value) {
+    const startedAt = Number(running.value);
+    const TWO_HOURS_MS = 2 * 60 * 60 * 1000;
+    if (!isNaN(startedAt) && Date.now() - startedAt < TWO_HOURS_MS) {
+      throw createError({
+        statusCode: 409,
+        statusMessage: "AniList sync already running",
+      });
+    }
+    if (!isNaN(startedAt)) {
+      console.warn(
+        `[AniList Sync] Stale lock detected (started ${new Date(startedAt).toISOString()}), proceeding anyway`
+      );
+    }
   }
 
   return runHourlyAniListSync();

--- a/server/api/private/anilist-airing-calendar.get.ts
+++ b/server/api/private/anilist-airing-calendar.get.ts
@@ -117,6 +117,10 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: "Missing query param: user" });
   }
 
+  if (!/^[a-zA-Z0-9_-]{1,30}$/.test(user)) {
+    throw createError({ statusCode: 400, statusMessage: "Invalid username format" });
+  }
+
   const storage = useStorage("cache");
   const cacheKey = `anilist:airing-calendar:${user.toLowerCase()}:${includePlanningNotYetReleased ? "planning" : "current"}`;
   const cached = await storage.getItem<{

--- a/server/api/private/anilist-user-list.get.ts
+++ b/server/api/private/anilist-user-list.get.ts
@@ -75,7 +75,12 @@ async function aniFetch(
   }
 
   if (!res.ok) {
-    throw createError({ statusCode: res.status, statusMessage: await res.text() });
+    const rawText = await res.text();
+    console.error(`[AniList] API error ${res.status}:`, rawText);
+    throw createError({
+      statusCode: res.status >= 500 ? 503 : res.status,
+      statusMessage: "External service error",
+    });
   }
 
   return res.json();
@@ -87,6 +92,10 @@ export default defineEventHandler(async (event) => {
 
   if (!user) {
     throw createError({ statusCode: 400, statusMessage: "Missing query param: user" });
+  }
+
+  if (!/^[a-zA-Z0-9_-]{1,30}$/.test(user)) {
+    throw createError({ statusCode: 400, statusMessage: "Invalid username format" });
   }
 
   await sleep(300);

--- a/server/api/private/anilist-user-list.get.ts
+++ b/server/api/private/anilist-user-list.get.ts
@@ -47,6 +47,8 @@ function normalizeStatusLists(
   }));
 }
 
+const ANILIST_REQUEST_DELAY_MS = 300;
+
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 async function aniFetch(
@@ -98,7 +100,7 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: "Invalid username format" });
   }
 
-  await sleep(300);
+  await sleep(ANILIST_REQUEST_DELAY_MS);
 
   const res = await aniFetch(USER_LIST_QUERY, { user });
   const lists = normalizeStatusLists(res);

--- a/server/api/private/history.get.ts
+++ b/server/api/private/history.get.ts
@@ -107,6 +107,22 @@ export default defineEventHandler(async (event) => {
     })
   }
 
+  const startDate = new Date(start as string)
+  const endDate = new Date(end as string)
+
+  if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) {
+    throw createError({ statusCode: 400, statusMessage: "Invalid date format" })
+  }
+
+  if (endDate < startDate) {
+    throw createError({ statusCode: 400, statusMessage: "End date must be after start date" })
+  }
+
+  const MAX_RANGE_MS = 366 * 24 * 60 * 60 * 1000 // ~1 year
+  if (endDate.getTime() - startDate.getTime() > MAX_RANGE_MS) {
+    throw createError({ statusCode: 400, statusMessage: "Date range too large (max 1 year)" })
+  }
+
   const toFuzzyDateInt = (dateStr: string) => parseInt(dateStr.replaceAll("-", ""))
 
   const startInt = toFuzzyDateInt(start as string)

--- a/server/api/private/history.get.ts
+++ b/server/api/private/history.get.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto"
 import { createError, defineEventHandler, getCookie, getQuery, setHeader } from "h3"
 import { enqueueAniList } from "../../../services/anilist/anilistQueue"
+import { getAniListAccessToken } from "../../utils/anilistAuth"
 import { prisma } from "../../../utils/prisma"
 import type {
   AniGraphQLResponse,
@@ -89,7 +90,7 @@ function getPageEntries(
 export default defineEventHandler(async (event) => {
   setHeader(event, "Cache-Control", `private, max-age=${RESULT_CACHE_TTL_SECONDS}`)
 
-  const token = getCookie(event, "anilist_token")
+  const token = await getAniListAccessToken(event)
 
   if (!token) {
     throw createError({

--- a/server/api/private/history.get.ts
+++ b/server/api/private/history.get.ts
@@ -107,22 +107,6 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const startDate = new Date(start as string)
-  const endDate = new Date(end as string)
-
-  if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) {
-    throw createError({ statusCode: 400, statusMessage: "Invalid date format" })
-  }
-
-  if (endDate < startDate) {
-    throw createError({ statusCode: 400, statusMessage: "End date must be after start date" })
-  }
-
-  const MAX_RANGE_MS = 366 * 24 * 60 * 60 * 1000 // ~1 year
-  if (endDate.getTime() - startDate.getTime() > MAX_RANGE_MS) {
-    throw createError({ statusCode: 400, statusMessage: "Date range too large (max 1 year)" })
-  }
-
   const toFuzzyDateInt = (dateStr: string) => parseInt(dateStr.replaceAll("-", ""))
 
   const startInt = toFuzzyDateInt(start as string)

--- a/server/api/private/recommendation.get.ts
+++ b/server/api/private/recommendation.get.ts
@@ -148,6 +148,10 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: "Missing user" });
   }
 
+  if (!/^[a-zA-Z0-9_-]{1,30}$/.test(user)) {
+    throw createError({ statusCode: 400, statusMessage: "Invalid username format" });
+  }
+
   const filterSeason =
     typeof q.season === "string" ? q.season.toUpperCase() : null;
 

--- a/server/api/private/recommendation.get.ts
+++ b/server/api/private/recommendation.get.ts
@@ -161,6 +161,8 @@ export default defineEventHandler(async (event) => {
   const episodesMax = parseNumber(q.episodesMax);
   const avgScoreMin = parseNumber(q.averageScoreMin);
   const avgScoreMax = parseNumber(q.averageScoreMax);
+  const minTagRankRaw = parseNumber(q.minTagRank);
+  const minTagRank = minTagRankRaw !== null ? Math.max(0, Math.min(100, Math.round(minTagRankRaw))) : 0;
 
   const includeGenres = parseList(q.genres) ?? [];
   const excludeGenres = parseList(q.excludeGenres) ?? [];
@@ -323,6 +325,7 @@ export default defineEventHandler(async (event) => {
 
   for (const tag of metadata.tags) {
     if (!metadataIdSet.has(tag.animeId)) continue;
+    if (minTagRank > 0 && (tag.rank === null || tag.rank < minTagRank)) continue;
     const compact = {
       tagId: tag.tagId,
       name: tag.name,

--- a/server/api/private/test-anilist-sync.post.ts
+++ b/server/api/private/test-anilist-sync.post.ts
@@ -1,6 +1,10 @@
-import { defineEventHandler } from "h3";
+import { createError, defineEventHandler } from "h3";
 import { runHourlyAniListSync } from "../../../services/anilist/hourlySync.service";
 
 export default defineEventHandler(async () => {
+  if (process.env.NODE_ENV !== "development") {
+    throw createError({ statusCode: 404, statusMessage: "Not Found" });
+  }
+
   return runHourlyAniListSync();
 });

--- a/server/api/public/health.get.ts
+++ b/server/api/public/health.get.ts
@@ -1,7 +1,20 @@
-export default defineEventHandler(() => {
-  const now = new Date().toISOString();
+import { prisma } from "../../../utils/prisma";
+
+export default defineEventHandler(async (_event) => {
+  const start = Date.now();
+  let dbStatus: "ok" | "error" = "ok";
+
+  try {
+    // simple lightweight query to verify DB is reachable
+    await prisma.anime.findFirst({ select: { id: true } });
+  } catch {
+    dbStatus = "error";
+  }
+
   return {
-    ok: true,
-    time: now,
+    ok: dbStatus === "ok",
+    time: new Date().toISOString(),
+    latencyMs: Date.now() - start,
+    database: dbStatus,
   };
 });

--- a/server/middleware/private-auth.ts
+++ b/server/middleware/private-auth.ts
@@ -1,6 +1,11 @@
-import { getCookie, createError, deleteCookie } from "h3"
+import { createError } from "h3"
 import crypto from "crypto"
 import type { AniViewerIdResponse } from "../types/api/auth"
+import {
+  clearAniListAuthCookies,
+  getAniListAccessToken,
+  refreshAniListAccessToken,
+} from "../utils/anilistAuth"
 
 const VERIFY_TTL_SECONDS = 60 * 5
 
@@ -11,7 +16,7 @@ function hasViewerId(response: AniViewerIdResponse): boolean {
 
 async function verifyAniListToken(token: string): Promise<boolean> {
   const storage = useStorage("cache")
-  const tokenHash = crypto.createHash("sha1").update(token).digest("hex")
+  const tokenHash = crypto.createHash("sha256").update(token).digest("hex")
   const cacheKey = `auth:anilist-token-valid:${tokenHash}`
   const cached = await storage.getItem<boolean>(cacheKey)
 
@@ -45,21 +50,26 @@ export default defineEventHandler(async (event) => {
     return
   }
 
-  const token = getCookie(event, "anilist_token")
-  if (!token) {
-    console.warn("[auth] rejected request:", {
-      url: event.node.req.url,
-      reason: "no_token",
-      timestamp: new Date().toISOString(),
-    })
-    throw createError({
-      statusCode: 401,
-      statusMessage: "Unauthorized",
-    })
-  }
-
   try {
-    const isValid = await verifyAniListToken(token)
+    let verifiedToken = await getAniListAccessToken(event)
+    if (!verifiedToken) {
+      console.warn("[auth] rejected request:", {
+        url: event.node.req.url,
+        reason: "no_token",
+        timestamp: new Date().toISOString(),
+      })
+      throw createError({
+        statusCode: 401,
+        statusMessage: "Unauthorized",
+      })
+    }
+
+    let isValid = await verifyAniListToken(verifiedToken)
+
+    if (!isValid) {
+      verifiedToken = await refreshAniListAccessToken(event)
+      isValid = verifiedToken ? await verifyAniListToken(verifiedToken) : false
+    }
 
     if (!isValid) {
       console.warn("[auth] rejected request:", {
@@ -67,7 +77,7 @@ export default defineEventHandler(async (event) => {
         reason: "invalid_token",
         timestamp: new Date().toISOString(),
       })
-      deleteCookie(event, "anilist_token", { path: "/" })
+      clearAniListAuthCookies(event)
       throw createError({
         statusCode: 401,
         statusMessage: "Unauthorized",

--- a/server/middleware/private-auth.ts
+++ b/server/middleware/private-auth.ts
@@ -47,6 +47,11 @@ export default defineEventHandler(async (event) => {
 
   const token = getCookie(event, "anilist_token")
   if (!token) {
+    console.warn("[auth] rejected request:", {
+      url: event.node.req.url,
+      reason: "no_token",
+      timestamp: new Date().toISOString(),
+    })
     throw createError({
       statusCode: 401,
       statusMessage: "Unauthorized",
@@ -57,6 +62,11 @@ export default defineEventHandler(async (event) => {
     const isValid = await verifyAniListToken(token)
 
     if (!isValid) {
+      console.warn("[auth] rejected request:", {
+        url: event.node.req.url,
+        reason: "invalid_token",
+        timestamp: new Date().toISOString(),
+      })
       deleteCookie(event, "anilist_token", { path: "/" })
       throw createError({
         statusCode: 401,

--- a/server/types/api/auth.ts
+++ b/server/types/api/auth.ts
@@ -1,5 +1,8 @@
 export interface AniOAuthTokenResponse {
   access_token?: string
+  refresh_token?: string
+  token_type?: string
+  expires_in?: number
 }
 
 export interface AniViewerNameResponse {

--- a/server/utils/anilistAuth.ts
+++ b/server/utils/anilistAuth.ts
@@ -7,10 +7,10 @@ const EXPIRES_AT_COOKIE = "anilist_token_expires_at"
 const REFRESH_SKEW_SECONDS = 60
 const DEFAULT_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365
 
-function getCookieOptions(maxAgeSeconds = DEFAULT_COOKIE_MAX_AGE_SECONDS) {
+function getCookieOptions(maxAgeSeconds = DEFAULT_COOKIE_MAX_AGE_SECONDS, sameSite: "lax" | "strict" = "strict") {
   return {
     httpOnly: true,
-    sameSite: "strict" as const,
+    sameSite,
     path: "/",
     secure: process.env.NODE_ENV === "production",
     maxAge: maxAgeSeconds,
@@ -34,7 +34,11 @@ export function setAniListAuthCookies(event: H3Event, tokenResponse: AniOAuthTok
     throw createError({ statusCode: 500, statusMessage: "No access token received" })
   }
 
-  setCookie(event, ACCESS_TOKEN_COOKIE, access_token, getCookieOptions(cookieMaxAge))
+  // Use "lax" for the access token so browsers include it in the redirect that
+  // follows the OAuth callback (a cross-site top-level navigation). "strict"
+  // would block the cookie from being sent on that redirect chain, preventing
+  // the guest middleware from detecting the authenticated state.
+  setCookie(event, ACCESS_TOKEN_COOKIE, access_token, getCookieOptions(cookieMaxAge, "lax"))
 
   if (refresh_token) {
     setCookie(event, REFRESH_TOKEN_COOKIE, refresh_token, getCookieOptions(DEFAULT_COOKIE_MAX_AGE_SECONDS))

--- a/server/utils/anilistAuth.ts
+++ b/server/utils/anilistAuth.ts
@@ -1,0 +1,123 @@
+import type { H3Event } from "h3"
+import type { AniOAuthTokenResponse } from "../types/api/auth"
+
+const ACCESS_TOKEN_COOKIE = "anilist_token"
+const REFRESH_TOKEN_COOKIE = "anilist_refresh_token"
+const EXPIRES_AT_COOKIE = "anilist_token_expires_at"
+const REFRESH_SKEW_SECONDS = 60
+const DEFAULT_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365
+
+function getCookieOptions(maxAgeSeconds = DEFAULT_COOKIE_MAX_AGE_SECONDS) {
+  return {
+    httpOnly: true,
+    sameSite: "strict" as const,
+    path: "/",
+    secure: process.env.NODE_ENV === "production",
+    maxAge: maxAgeSeconds,
+    expires: new Date(Date.now() + maxAgeSeconds * 1000),
+  }
+}
+
+export function clearAniListAuthCookies(event: H3Event) {
+  deleteCookie(event, ACCESS_TOKEN_COOKIE, { path: "/" })
+  deleteCookie(event, REFRESH_TOKEN_COOKIE, { path: "/" })
+  deleteCookie(event, EXPIRES_AT_COOKIE, { path: "/" })
+}
+
+export function setAniListAuthCookies(event: H3Event, tokenResponse: AniOAuthTokenResponse) {
+  const { access_token, refresh_token, expires_in } = tokenResponse
+  const cookieMaxAge = typeof expires_in === "number" && Number.isFinite(expires_in)
+    ? expires_in
+    : DEFAULT_COOKIE_MAX_AGE_SECONDS
+
+  if (!access_token) {
+    throw createError({ statusCode: 500, statusMessage: "No access token received" })
+  }
+
+  setCookie(event, ACCESS_TOKEN_COOKIE, access_token, getCookieOptions(cookieMaxAge))
+
+  if (refresh_token) {
+    setCookie(event, REFRESH_TOKEN_COOKIE, refresh_token, getCookieOptions(DEFAULT_COOKIE_MAX_AGE_SECONDS))
+  }
+
+  if (typeof expires_in === "number" && Number.isFinite(expires_in)) {
+    const expiresAt = Date.now() + expires_in * 1000
+    setCookie(event, EXPIRES_AT_COOKIE, String(expiresAt), getCookieOptions(cookieMaxAge))
+  } else {
+    deleteCookie(event, EXPIRES_AT_COOKIE, { path: "/" })
+  }
+}
+
+export function getAniListAccessTokenFromCookies(event: H3Event): string | null {
+  const token = getCookie(event, ACCESS_TOKEN_COOKIE)
+  return typeof token === "string" && token.length > 0 ? token : null
+}
+
+function getAniListRefreshTokenFromCookies(event: H3Event): string | null {
+  const token = getCookie(event, REFRESH_TOKEN_COOKIE)
+  return typeof token === "string" && token.length > 0 ? token : null
+}
+
+function getAniListExpiresAt(event: H3Event): number | null {
+  const value = getCookie(event, EXPIRES_AT_COOKIE)
+  if (!value) return null
+
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function shouldRefreshAccessToken(event: H3Event): boolean {
+  const expiresAt = getAniListExpiresAt(event)
+  if (!expiresAt) return false
+
+  return Date.now() >= expiresAt - REFRESH_SKEW_SECONDS * 1000
+}
+
+export async function refreshAniListAccessToken(event: H3Event): Promise<string | null> {
+  const refreshToken = getAniListRefreshTokenFromCookies(event)
+
+  if (!refreshToken) {
+    return null
+  }
+
+  const config = useRuntimeConfig()
+  const params = new URLSearchParams({
+    grant_type: "refresh_token",
+    client_id: config.anilistClientId,
+    client_secret: config.anilistClientSecret,
+    refresh_token: refreshToken,
+  })
+
+  try {
+    const tokenRes = await $fetch<AniOAuthTokenResponse>(
+      "https://anilist.co/api/v2/oauth/token",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: params.toString(),
+      }
+    )
+
+    setAniListAuthCookies(event, tokenRes)
+    return tokenRes.access_token ?? null
+  } catch {
+    clearAniListAuthCookies(event)
+    return null
+  }
+}
+
+export async function getAniListAccessToken(event: H3Event): Promise<string | null> {
+  const accessToken = getAniListAccessTokenFromCookies(event)
+
+  if (!accessToken) {
+    return await refreshAniListAccessToken(event)
+  }
+
+  if (!shouldRefreshAccessToken(event)) {
+    return accessToken
+  }
+
+  return (await refreshAniListAccessToken(event)) ?? accessToken
+}

--- a/services/anilist/anilistClient.ts
+++ b/services/anilist/anilistClient.ts
@@ -58,9 +58,17 @@ export async function anilistRequest<T>(
   const existing = inFlightRequests.get(key) as Promise<T> | undefined;
   if (existing) return existing;
 
-  const request = performAniListRequest<T>(query, variables, attempt).finally(() => {
+  if (inFlightRequests.size >= 200) {
+    const firstKey = inFlightRequests.keys().next().value;
+    if (firstKey !== undefined) inFlightRequests.delete(firstKey);
+  }
+
+  const promise = performAniListRequest<T>(query, variables, attempt);
+  const cleanup = setTimeout(() => inFlightRequests.delete(key), 60_000);
+  const request = promise.finally(() => {
+    clearTimeout(cleanup);
     inFlightRequests.delete(key);
-  });
+  }) as Promise<T>;
 
   inFlightRequests.set(key, request as Promise<unknown>);
   return request;

--- a/services/anilist/anilistClient.ts
+++ b/services/anilist/anilistClient.ts
@@ -58,17 +58,9 @@ export async function anilistRequest<T>(
   const existing = inFlightRequests.get(key) as Promise<T> | undefined;
   if (existing) return existing;
 
-  if (inFlightRequests.size >= 200) {
-    const firstKey = inFlightRequests.keys().next().value;
-    if (firstKey !== undefined) inFlightRequests.delete(firstKey);
-  }
-
-  const promise = performAniListRequest<T>(query, variables, attempt);
-  const cleanup = setTimeout(() => inFlightRequests.delete(key), 60_000);
-  const request = promise.finally(() => {
-    clearTimeout(cleanup);
+  const request = performAniListRequest<T>(query, variables, attempt).finally(() => {
     inFlightRequests.delete(key);
-  }) as Promise<T>;
+  });
 
   inFlightRequests.set(key, request as Promise<unknown>);
   return request;

--- a/services/anilist/hourlySync.service.ts
+++ b/services/anilist/hourlySync.service.ts
@@ -9,8 +9,8 @@ export async function runHourlyAniListSync() {
 
   await prisma.syncState.upsert({
     where: { key: "anilist_sync_running" },
-    update: { value: String(Date.now()) },
-    create: { key: "anilist_sync_running", value: String(Date.now()) },
+    update: { value: "1" },
+    create: { key: "anilist_sync_running", value: "1" },
   })
 
   const state = await prisma.syncState.findUnique({
@@ -59,17 +59,12 @@ export async function runHourlyAniListSync() {
         `[AniList Sync] checking anime id=${m.id} updatedAt=${m.updatedAt}`
       )
 
-      try {
-        const changed = await syncAnime(m.id)
-        checked++
+      const changed = await syncAnime(m.id)
+      checked++
 
-        if (changed) {
-          written++
-          changedOnThisPage = true
-        }
-      } catch (err) {
-        console.error(`[AniList Sync] Failed to sync anime ${m.id}:`, err)
-        // continue to next anime
+      if (changed) {
+        written++
+        changedOnThisPage = true
       }
 
       if (m.updatedAt > newestSeen) {

--- a/services/anilist/hourlySync.service.ts
+++ b/services/anilist/hourlySync.service.ts
@@ -9,8 +9,8 @@ export async function runHourlyAniListSync() {
 
   await prisma.syncState.upsert({
     where: { key: "anilist_sync_running" },
-    update: { value: "1" },
-    create: { key: "anilist_sync_running", value: "1" },
+    update: { value: String(Date.now()) },
+    create: { key: "anilist_sync_running", value: String(Date.now()) },
   })
 
   const state = await prisma.syncState.findUnique({
@@ -59,12 +59,17 @@ export async function runHourlyAniListSync() {
         `[AniList Sync] checking anime id=${m.id} updatedAt=${m.updatedAt}`
       )
 
-      const changed = await syncAnime(m.id)
-      checked++
+      try {
+        const changed = await syncAnime(m.id)
+        checked++
 
-      if (changed) {
-        written++
-        changedOnThisPage = true
+        if (changed) {
+          written++
+          changedOnThisPage = true
+        }
+      } catch (err) {
+        console.error(`[AniList Sync] Failed to sync anime ${m.id}:`, err)
+        // continue to next anime
       }
 
       if (m.updatedAt > newestSeen) {

--- a/services/anilist/syncAnime.ts
+++ b/services/anilist/syncAnime.ts
@@ -2,6 +2,8 @@ import { prisma } from "../../utils/prisma";
 import { anilistRequest } from "./anilistClient";
 import crypto from "crypto";
 
+const ANILIST_REQUEST_DELAY_MS = 300;
+
 const QUERY = `
 query FullAnime($id: Int!) {
   Media(id: $id, type: ANIME) {
@@ -258,5 +260,5 @@ export async function syncAnime(anilistId: number) {
   }
 
   // Mini Rate-Limit Guard
-  await new Promise((r) => setTimeout(r, 300));
+  await new Promise((r) => setTimeout(r, ANILIST_REQUEST_DELAY_MS));
 }

--- a/services/anilist/syncAnime.ts
+++ b/services/anilist/syncAnime.ts
@@ -92,7 +92,7 @@ type FullAnimeResponse = {
 
 function hashAnime(m: FullAnimeResponse["Media"]) {
   return crypto
-    .createHash("sha1")
+    .createHash("sha256")
     .update(
       JSON.stringify({
         en: m.title.english,

--- a/tests/api.auth.test.ts
+++ b/tests/api.auth.test.ts
@@ -4,9 +4,18 @@ function createEvent() {
   return {} as any
 }
 
+const cookieState = {
+  anilist_token: undefined as string | undefined,
+  anilist_refresh_token: undefined as string | undefined,
+  anilist_token_expires_at: undefined as string | undefined,
+}
+
 describe("api/auth/login.get", () => {
   beforeEach(() => {
     vi.resetModules()
+    cookieState.anilist_token = undefined
+    cookieState.anilist_refresh_token = undefined
+    cookieState.anilist_token_expires_at = undefined
     ;(globalThis as any).defineEventHandler = (handler: any) => handler
     ;(globalThis as any).useRuntimeConfig = () => ({
       anilistClientId: "client-123",
@@ -31,6 +40,9 @@ describe("api/auth/login.get", () => {
 describe("api/auth/callback.get", () => {
   beforeEach(() => {
     vi.resetModules()
+    cookieState.anilist_token = undefined
+    cookieState.anilist_refresh_token = undefined
+    cookieState.anilist_token_expires_at = undefined
     ;(globalThis as any).defineEventHandler = (handler: any) => handler
     ;(globalThis as any).createError = vi.fn((input: any) => {
       const err = new Error(input.statusMessage) as any
@@ -45,6 +57,7 @@ describe("api/auth/callback.get", () => {
     })
     ;(globalThis as any).getQuery = vi.fn(() => ({}))
     ;(globalThis as any).setCookie = vi.fn()
+    ;(globalThis as any).deleteCookie = vi.fn()
     ;(globalThis as any).sendRedirect = vi.fn((_event: any, to: string) => to)
     ;(globalThis as any).$fetch = vi.fn()
   })
@@ -60,7 +73,11 @@ describe("api/auth/callback.get", () => {
 
   it("stores token and redirects on valid oauth exchange", async () => {
     ;(globalThis as any).getQuery = vi.fn(() => ({ code: "abc123" }))
-    ;(globalThis as any).$fetch = vi.fn(async () => ({ access_token: "token-1" }))
+    ;(globalThis as any).$fetch = vi.fn(async () => ({
+      access_token: "token-1",
+      refresh_token: "refresh-1",
+      expires_in: 3600,
+    }))
 
     const mod = await import("../server/api/auth/callback.get")
     const out = await mod.default(createEvent())
@@ -69,7 +86,19 @@ describe("api/auth/callback.get", () => {
       expect.anything(),
       "anilist_token",
       "token-1",
-      expect.objectContaining({ httpOnly: true, path: "/" })
+      expect.objectContaining({ httpOnly: true, path: "/", maxAge: 3600, expires: expect.any(Date) })
+    )
+    expect((globalThis as any).setCookie).toHaveBeenCalledWith(
+      expect.anything(),
+      "anilist_refresh_token",
+      "refresh-1",
+      expect.objectContaining({ httpOnly: true, path: "/", maxAge: 60 * 60 * 24 * 365, expires: expect.any(Date) })
+    )
+    expect((globalThis as any).setCookie).toHaveBeenCalledWith(
+      expect.anything(),
+      "anilist_token_expires_at",
+      expect.any(String),
+      expect.objectContaining({ httpOnly: true, path: "/", maxAge: 3600, expires: expect.any(Date) })
     )
     expect(out).toBe("/")
   })
@@ -78,6 +107,9 @@ describe("api/auth/callback.get", () => {
 describe("api/auth/logout.post", () => {
   beforeEach(() => {
     vi.resetModules()
+    cookieState.anilist_token = undefined
+    cookieState.anilist_refresh_token = undefined
+    cookieState.anilist_token_expires_at = undefined
     ;(globalThis as any).defineEventHandler = (handler: any) => handler
     ;(globalThis as any).deleteCookie = vi.fn()
     ;(globalThis as any).sendRedirect = vi.fn((_event: any, to: string) => to)
@@ -92,6 +124,16 @@ describe("api/auth/logout.post", () => {
       "anilist_token",
       { path: "/" }
     )
+    expect((globalThis as any).deleteCookie).toHaveBeenCalledWith(
+      expect.anything(),
+      "anilist_refresh_token",
+      { path: "/" }
+    )
+    expect((globalThis as any).deleteCookie).toHaveBeenCalledWith(
+      expect.anything(),
+      "anilist_token_expires_at",
+      { path: "/" }
+    )
     expect(out).toBe("/")
   })
 })
@@ -99,8 +141,23 @@ describe("api/auth/logout.post", () => {
 describe("api/auth/me.get", () => {
   beforeEach(() => {
     vi.resetModules()
+    cookieState.anilist_token = undefined
+    cookieState.anilist_refresh_token = undefined
+    cookieState.anilist_token_expires_at = undefined
     ;(globalThis as any).defineEventHandler = (handler: any) => handler
-    ;(globalThis as any).getCookie = vi.fn(() => undefined)
+    ;(globalThis as any).getCookie = vi.fn((_event: any, name: keyof typeof cookieState) => cookieState[name])
+    ;(globalThis as any).setCookie = vi.fn()
+    ;(globalThis as any).deleteCookie = vi.fn()
+    ;(globalThis as any).useRuntimeConfig = () => ({
+      anilistClientId: "client-123",
+      anilistClientSecret: "secret-abc",
+    })
+    ;(globalThis as any).createError = vi.fn((input: any) => {
+      const err = new Error(input.statusMessage) as any
+      err.statusCode = input.statusCode
+      err.statusMessage = input.statusMessage
+      return err
+    })
     ;(globalThis as any).$fetch = vi.fn()
   })
 
@@ -110,7 +167,7 @@ describe("api/auth/me.get", () => {
   })
 
   it("returns viewer name for valid token", async () => {
-    ;(globalThis as any).getCookie = vi.fn(() => "token-abc")
+    cookieState.anilist_token = "token-abc"
     ;(globalThis as any).$fetch = vi.fn(async () => ({
       data: { Viewer: { name: "Leon" } },
     }))
@@ -122,12 +179,41 @@ describe("api/auth/me.get", () => {
   })
 
   it("returns null user if AniList call fails", async () => {
-    ;(globalThis as any).getCookie = vi.fn(() => "token-abc")
+    cookieState.anilist_token = "token-abc"
     ;(globalThis as any).$fetch = vi.fn(async () => {
       throw new Error("request failed")
     })
 
     const mod = await import("../server/api/auth/me.get")
     await expect(mod.default(createEvent())).resolves.toEqual({ user: null })
+  })
+
+  it("refreshes the access token before loading the user when expired", async () => {
+    cookieState.anilist_token = "expired-token"
+    cookieState.anilist_refresh_token = "refresh-1"
+    cookieState.anilist_token_expires_at = String(Date.now() - 1000)
+
+    ;(globalThis as any).$fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        access_token: "token-2",
+        refresh_token: "refresh-2",
+        expires_in: 3600,
+      })
+      .mockResolvedValueOnce({
+        data: { Viewer: { name: "Leon" } },
+      })
+
+    const mod = await import("../server/api/auth/me.get")
+    await expect(mod.default(createEvent())).resolves.toEqual({
+      user: { name: "Leon" },
+    })
+
+    expect((globalThis as any).setCookie).toHaveBeenCalledWith(
+      expect.anything(),
+      "anilist_token",
+      "token-2",
+      expect.anything()
+    )
   })
 })

--- a/tests/api.cron-anilist-sync.test.ts
+++ b/tests/api.cron-anilist-sync.test.ts
@@ -30,7 +30,7 @@ describe("api/cron/anilist-sync.get", () => {
   })
 
   it("returns 409 when sync is already running", async () => {
-    state.runningValue = String(Date.now())
+    state.runningValue = "1"
     const mod = await import("../server/api/cron/anilist-sync.get")
 
     await expect(mod.default({} as any)).rejects.toMatchObject({

--- a/tests/api.cron-anilist-sync.test.ts
+++ b/tests/api.cron-anilist-sync.test.ts
@@ -30,7 +30,7 @@ describe("api/cron/anilist-sync.get", () => {
   })
 
   it("returns 409 when sync is already running", async () => {
-    state.runningValue = "1"
+    state.runningValue = String(Date.now())
     const mod = await import("../server/api/cron/anilist-sync.get")
 
     await expect(mod.default({} as any)).rejects.toMatchObject({

--- a/tests/api.private-history.test.ts
+++ b/tests/api.private-history.test.ts
@@ -7,18 +7,23 @@ const state = vi.hoisted(() => ({
 
 const prismaFindManyMock = vi.hoisted(() => vi.fn(async () => []))
 
-vi.mock("h3", () => ({
-  defineEventHandler: (handler: any) => handler,
-  setHeader: () => {},
-  getCookie: () => state.token,
-  getQuery: () => state.query,
-  createError: (input: { statusCode: number; statusMessage: string }) => {
-    const err = new Error(input.statusMessage) as any
-    err.statusCode = input.statusCode
-    err.statusMessage = input.statusMessage
-    return err
-  },
-}))
+vi.mock("h3", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("h3")>()
+
+  return {
+    ...actual,
+    createError: (input: { statusCode: number; statusMessage: string }) => {
+      const err = new Error(input.statusMessage) as any
+      err.statusCode = input.statusCode
+      err.statusMessage = input.statusMessage
+      return err
+    },
+    defineEventHandler: (handler: any) => handler,
+    getCookie: (_event: any, _name: string) => state.token,
+    getQuery: () => state.query,
+    setHeader: vi.fn(),
+  }
+})
 
 vi.mock("../utils/prisma", () => ({
   prisma: {
@@ -35,13 +40,21 @@ describe("api/private/history.get", () => {
     state.query = {}
     prismaFindManyMock.mockReset()
     ;(globalThis as any).defineEventHandler = (handler: any) => handler
-    ;(globalThis as any).getCookie = () => state.token
+    ;(globalThis as any).getCookie = (_event: any, _name: string) => state.token
     ;(globalThis as any).getQuery = () => state.query
-    ;(globalThis as any).$fetch = vi.fn()
-    ;(globalThis as any).useStorage = () => ({
-      getItem: vi.fn(async () => null),
-      setItem: vi.fn(async () => undefined),
+    ;(globalThis as any).setHeader = vi.fn()
+    ;(globalThis as any).deleteCookie = vi.fn()
+    ;(globalThis as any).setCookie = vi.fn()
+    ;(globalThis as any).useRuntimeConfig = () => ({
+      anilistClientId: "client-123",
+      anilistClientSecret: "secret-abc",
     })
+    ;(globalThis as any).useStorage = vi.fn(() => ({
+      getItem: vi.fn(async () => undefined),
+      setItem: vi.fn(async () => undefined),
+    }))
+    ;(globalThis as any).$fetch = vi.fn()
+    ;(globalThis as any).fetch = vi.fn()
   })
 
   it("returns 401 when auth token is missing", async () => {

--- a/tests/api.private-history.test.ts
+++ b/tests/api.private-history.test.ts
@@ -8,6 +8,10 @@ const state = vi.hoisted(() => ({
 const prismaFindManyMock = vi.hoisted(() => vi.fn(async () => []))
 
 vi.mock("h3", () => ({
+  defineEventHandler: (handler: any) => handler,
+  setHeader: () => {},
+  getCookie: () => state.token,
+  getQuery: () => state.query,
   createError: (input: { statusCode: number; statusMessage: string }) => {
     const err = new Error(input.statusMessage) as any
     err.statusCode = input.statusCode
@@ -34,6 +38,10 @@ describe("api/private/history.get", () => {
     ;(globalThis as any).getCookie = () => state.token
     ;(globalThis as any).getQuery = () => state.query
     ;(globalThis as any).$fetch = vi.fn()
+    ;(globalThis as any).useStorage = () => ({
+      getItem: vi.fn(async () => null),
+      setItem: vi.fn(async () => undefined),
+    })
   })
 
   it("returns 401 when auth token is missing", async () => {
@@ -58,10 +66,18 @@ describe("api/private/history.get", () => {
     state.token = "token-1"
     state.query = { start: "2025-01-01", end: "2025-12-31" }
 
-    ;(globalThis as any).$fetch = vi
+    const makeJsonResponse = (data: unknown) => ({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      json: async () => data,
+      text: async () => "",
+    })
+
+    ;(globalThis as any).fetch = vi
       .fn()
-      .mockResolvedValueOnce({ data: { Viewer: { id: 7 } } })
-      .mockResolvedValueOnce({
+      .mockResolvedValueOnce(makeJsonResponse({ data: { Viewer: { id: 7 } } }))
+      .mockResolvedValueOnce(makeJsonResponse({
         data: {
           Page: {
             pageInfo: { hasNextPage: false },
@@ -74,7 +90,7 @@ describe("api/private/history.get", () => {
             ],
           },
         },
-      })
+      }))
 
     prismaFindManyMock.mockResolvedValueOnce([
       {

--- a/tests/api.private-test-anilist-sync.test.ts
+++ b/tests/api.private-test-anilist-sync.test.ts
@@ -7,10 +7,17 @@ vi.mock("../services/anilist/hourlySync.service", () => ({
 }))
 
 describe("api/private/test-anilist-sync.post", () => {
+  const originalNodeEnv = process.env.NODE_ENV
+
   beforeEach(() => {
     vi.resetModules()
     ;(globalThis as any).defineEventHandler = (handler: any) => handler
     runHourlyAniListSyncMock.mockClear()
+    process.env.NODE_ENV = "development"
+  })
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv
   })
 
   it("delegates to runHourlyAniListSync", async () => {
@@ -19,5 +26,11 @@ describe("api/private/test-anilist-sync.post", () => {
 
     await expect(mod.default()).resolves.toEqual({ synced: 3 })
     expect(runHourlyAniListSyncMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("returns 404 outside development", async () => {
+    process.env.NODE_ENV = "production"
+    const mod = await import("../server/api/private/test-anilist-sync.post")
+    await expect(mod.default()).rejects.toMatchObject({ statusCode: 404 })
   })
 })

--- a/tests/api.public-health.test.ts
+++ b/tests/api.public-health.test.ts
@@ -1,16 +1,38 @@
-import { beforeEach, describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("../utils/prisma", () => ({
+  prisma: {
+    anime: {
+      findFirst: vi.fn(async () => ({ id: 1 })),
+    },
+  },
+}))
 
 describe("api/public/health.get", () => {
   beforeEach(() => {
+    vi.resetModules()
     ;(globalThis as any).defineEventHandler = (handler: any) => handler
   })
 
-  it("returns ok and an ISO timestamp", async () => {
+  it("returns ok and an ISO timestamp when DB is reachable", async () => {
     const mod = await import("../server/api/public/health.get")
     const out = await mod.default()
 
     expect(out.ok).toBe(true)
+    expect(out.database).toBe("ok")
     expect(typeof out.time).toBe("string")
     expect(new Date(out.time).toString()).not.toBe("Invalid Date")
+    expect(typeof out.latencyMs).toBe("number")
+  })
+
+  it("returns ok=false when DB is unreachable", async () => {
+    const { prisma } = await import("../utils/prisma")
+    vi.mocked(prisma.anime.findFirst).mockRejectedValueOnce(new Error("connection refused"))
+
+    const mod = await import("../server/api/public/health.get")
+    const out = await mod.default()
+
+    expect(out.ok).toBe(false)
+    expect(out.database).toBe("error")
   })
 })

--- a/tests/private-auth.middleware.test.ts
+++ b/tests/private-auth.middleware.test.ts
@@ -2,9 +2,16 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const h3State = {
   token: undefined as string | undefined,
+  refreshToken: undefined as string | undefined,
+  expiresAt: undefined as string | undefined,
 }
 
-const getCookieMock = vi.fn(() => h3State.token)
+const getCookieMock = vi.fn((_event: any, name: string) => {
+  if (name === "anilist_token") return h3State.token
+  if (name === "anilist_refresh_token") return h3State.refreshToken
+  if (name === "anilist_token_expires_at") return h3State.expiresAt
+  return undefined
+})
 const deleteCookieMock = vi.fn()
 const createErrorMock = vi.fn((input: { statusCode: number; statusMessage: string }) => {
   const err = new Error(input.statusMessage) as Error & {
@@ -42,9 +49,17 @@ function createEvent(url: string) {
 
 function installNuxtGlobals(fetchImpl: ReturnType<typeof vi.fn>) {
   ;(globalThis as any).defineEventHandler = (handler: any) => handler
+  ;(globalThis as any).getCookie = getCookieMock
+  ;(globalThis as any).deleteCookie = deleteCookieMock
+  ;(globalThis as any).setCookie = vi.fn()
+  ;(globalThis as any).createError = createErrorMock
   ;(globalThis as any).useStorage = vi.fn(() => ({
     getItem: storageGetItemMock,
     setItem: storageSetItemMock,
+  }))
+  ;(globalThis as any).useRuntimeConfig = vi.fn(() => ({
+    anilistClientId: "client-123",
+    anilistClientSecret: "secret-abc",
   }))
   ;(globalThis as any).$fetch = fetchImpl
 }
@@ -60,6 +75,8 @@ describe("server/middleware/private-auth", () => {
     vi.clearAllMocks()
     cache.clear()
     h3State.token = undefined
+    h3State.refreshToken = undefined
+    h3State.expiresAt = undefined
   })
 
   it("ignores non-private routes", async () => {
@@ -117,7 +134,7 @@ describe("server/middleware/private-auth", () => {
       statusCode: 401,
       statusMessage: "Unauthorized",
     })
-    expect(deleteCookieMock).toHaveBeenCalledTimes(1)
+    expect(deleteCookieMock).toHaveBeenCalledTimes(3)
   })
 
   it("returns 503 when token verification fails unexpectedly", async () => {
@@ -132,5 +149,32 @@ describe("server/middleware/private-auth", () => {
       statusCode: 503,
       statusMessage: "Authentication verification failed",
     })
+  })
+
+  it("refreshes an expired token before verification", async () => {
+    h3State.token = "expired-token"
+    h3State.refreshToken = "refresh-1"
+    h3State.expiresAt = String(Date.now() - 1000)
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        access_token: "token-2",
+        refresh_token: "refresh-2",
+        expires_in: 3600,
+      })
+      .mockResolvedValueOnce({ data: { Viewer: { id: 123 } } })
+
+    installNuxtGlobals(fetchMock)
+    const handler = await loadHandler()
+
+    await expect(handler(createEvent("/api/private/recommendation"))).resolves.toBeUndefined()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect((globalThis as any).setCookie).toHaveBeenCalledWith(
+      expect.anything(),
+      "anilist_token",
+      "token-2",
+      expect.anything()
+    )
   })
 })


### PR DESCRIPTION
## Summary

This release brings **8 commits** from `staging` into `main`, covering a complete auth overhaul, backend reliability & security hardening, frontend quality improvements and two new user-facing features.

---

### 🔐 Auth Refresh & Security Hardening (PR #42)
- **Refreshable AniList token**: New `anilistAuth.ts` util with `getAniListAccessToken` / `refreshAniListAccessToken` / `clearAniListAuthCookies`
- **sameSite strict**: Auth cookies upgraded from `lax` to `strict`
- **Security & logic bug fixes** in token handling (callback, logout, me, history)
- **Auth rejection logging**: URL, reason and timestamp logged on every 401

### 🔒 Backend Security (PR #44)
- **Cron endpoint auth**: `CRON_SECRET` Bearer token check; warns if unset
- **Username validation**: Regex `/^[a-zA-Z0-9_-]{1,30}/` on all `user` params
- **Error sanitization**: External AniList errors no longer forwarded verbatim
- **SHA256 instead of SHA1** in `syncAnime.ts`
- **Test endpoint dev-only**: returns 404 outside `development`

### 🛡️ Backend Reliability (PR #43)
- **Stale lock detection**: Cron lock uses timestamp; locks > 2 h are bypassed
- **In-flight cache limit**: capped at 200 entries with 60 s cleanup timeout
- **Date validation** in `history.get.ts` (valid dates, end ≥ start, max 1 year)
- **Per-anime error isolation**: single failure no longer aborts full sync

### 🧹 Minor Quality (PR #46)
- **Health endpoint** pings DB and returns `{ ok, database, latencyMs }`
- **Null safety** in `episodeDist` computed
- **`ANILIST_REQUEST_DELAY_MS`** constant replaces magic 300 ms
- **Auth rejection logging** in `private-auth.ts`

### 🖥️ Frontend Quality (PR #45)
- Removed duplicate ECharts `use()` registration
- `useAnilistUser()` composable used consistently across pages
- Client-side username format validation before API calls
- Error logging in all `catch {}` blocks

### ✨ Feature: Profile Milestones (closes #5)
- Milestones section in Dashboard (anime count + watch-time), EN/DE

### ✨ Feature: Configurable Min Tag Threshold (closes #11, PR #47)
- `minTagRank` param in recommendation endpoint + range slider in UI

### 🧪 Test Fix
- `api.private-history.test.ts`: Fixed broken h3 mock (pre-existing bug)

---

## Test Results (Staging — final)
| Suite | Result |
|-------|--------|
| Backend (13 files) | ✅ **44 / 44 passed** |
| Frontend (4 files) | ✅ **9 / 9 passed** |
| Performance (1 file) | ✅ **4 / 4 passed** (1 skipped – needs live user) |

## ⚠️ Do not merge until manual smoke test on staging is confirmed.