### PR TITLE
fix: use SameSite=Lax for access token to fix post-login redirect

### DIFF
--- a/server/utils/anilistAuth.ts
+++ b/server/utils/anilistAuth.ts
@@ -7,10 +7,10 @@ const EXPIRES_AT_COOKIE = "anilist_token_expires_at"
 const REFRESH_SKEW_SECONDS = 60
 const DEFAULT_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365
 
-function getCookieOptions(maxAgeSeconds = DEFAULT_COOKIE_MAX_AGE_SECONDS) {
+function getCookieOptions(maxAgeSeconds = DEFAULT_COOKIE_MAX_AGE_SECONDS, sameSite: "lax" | "strict" = "strict") {
   return {
     httpOnly: true,
-    sameSite: "strict" as const,
+    sameSite,
     path: "/",
     secure: process.env.NODE_ENV === "production",
     maxAge: maxAgeSeconds,
@@ -34,7 +34,11 @@ export function setAniListAuthCookies(event: H3Event, tokenResponse: AniOAuthTok
     throw createError({ statusCode: 500, statusMessage: "No access token received" })
   }
 
-  setCookie(event, ACCESS_TOKEN_COOKIE, access_token, getCookieOptions(cookieMaxAge))
+  // Use "lax" for the access token so browsers include it in the redirect that
+  // follows the OAuth callback (a cross-site top-level navigation). "strict"
+  // would block the cookie from being sent on that redirect chain, preventing
+  // the guest middleware from detecting the authenticated state.
+  setCookie(event, ACCESS_TOKEN_COOKIE, access_token, getCookieOptions(cookieMaxAge, "lax"))
 
   if (refresh_token) {
     setCookie(event, REFRESH_TOKEN_COOKIE, refresh_token, getCookieOptions(DEFAULT_COOKIE_MAX_AGE_SECONDS))


### PR DESCRIPTION
## Summary

- **Root cause:** PR #42 upgraded the  cookie from  to  in . With , browsers do not send the cookie when following redirect chains that originate from a cross-site context. After the OAuth callback from , the browser follows a 302 redirect to  — but since this is still part of the cross-site navigation initiated from , the  cookie is not included in that request.
- **Effect:** The  middleware reads  via  from the incoming request. Because the cookie isn't sent, the middleware finds no token and does not redirect to  — the user stays on the login page.
- **Fix:** Change the access token () to . Lax allows the cookie to be sent on top-level GET navigations (including cross-site redirects), which is the correct semantics for an OAuth callback flow. The refresh token and expires-at cookies remain  since they are only ever accessed server-side in API requests, never in cross-site navigation chains.

## Test plan

- [ ] Log in via AniList OAuth — confirm you are redirected to  instead of remaining on - [ ] Log out — confirm you are redirected to  and cannot access protected routes
- [ ] Reload  while logged in — confirm you stay on the dashboard
- [ ] Reload  while logged in — confirm you are redirected to - [ ] Access a private API route () without a token — confirm 401 is returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)