### PR TITLE
fix(#65): Normalize scores to 0-100 before taste comparison

### DIFF
--- a/app/pages/compare.vue
+++ b/app/pages/compare.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { api } from "~/composables/useApi";
 import { normalizeAnilist } from "~/utils/normalizeAnilist";
+import { normalizeScoreTo100 } from "~/utils/normalizeScore";
 import type { AnimeEntry } from "~/types/anime";
 import type {
   ApiAnilistResponse,
@@ -30,6 +31,7 @@ const loading = ref(false);
 const error = ref<string | null>(null);
 
 const entriesByUser = ref<Record<string, AnimeEntry[]>>({});
+const scoreFormatByUser = ref<Record<string, string | null>>({});
 const allAnime = ref<CompareAnimeItem[]>([]);
 
 const search = ref("");
@@ -95,6 +97,7 @@ async function addUser() {
 function removeUser(name: string) {
   users.value = users.value.filter((u) => u !== name);
   delete entriesByUser.value[name];
+  delete scoreFormatByUser.value[name];
 }
 
 async function loadSingleUser(username: string) {
@@ -107,6 +110,7 @@ async function loadSingleUser(username: string) {
     });
 
     entriesByUser.value[username] = normalizeAnilist(res.data.data.MediaListCollection.lists);
+    scoreFormatByUser.value[username] = res.data.data.scoreFormat ?? null;
   } catch (e) {
     console.error("[Compare]", e);
     error.value = `${t("common.errorPrefix")}: ${t("compare.loadError")}`;
@@ -290,9 +294,15 @@ function compareValues(a: number | string, b: number | string, direction: SortDi
   return direction === "asc" ? cmp : -cmp;
 }
 
+function normalizedScore(user: string, entry: AnimeEntry): number {
+  const raw = Number(entry.score ?? 0);
+  if (raw === 0) return 0;
+  return normalizeScoreTo100(raw, scoreFormatByUser.value[user]);
+}
+
 function averageScore(anime: CompareAnimeItem) {
-  const values = Object.values(anime.users)
-    .map((entry) => Number(entry.score ?? 0))
+  const values = Object.entries(anime.users)
+    .map(([user, entry]) => normalizedScore(user, entry))
     .filter((value) => value > 0);
 
   if (!values.length) return 0;
@@ -647,7 +657,13 @@ watch(
             </div>
 
             <template v-if="a.users[u]">
-              <div class="text-xs text-zinc-400">{{ t("common.score") }}: {{ a.users[u].score || "-" }}</div>
+              <div class="text-xs text-zinc-400">
+                {{ t("common.score") }}: {{ a.users[u].score || "-" }}
+                <span
+                  v-if="a.users[u].score && scoreFormatByUser[u] && scoreFormatByUser[u] !== 'POINT_100'"
+                  class="text-zinc-500"
+                >({{ normalizedScore(u, a.users[u]).toFixed(0) }}/100)</span>
+              </div>
             </template>
           </div>
         </div>

--- a/app/types/api.ts
+++ b/app/types/api.ts
@@ -83,6 +83,7 @@ export interface ApiUserListResponse {
 
 export interface ApiAnilistResponse {
   data: {
+    scoreFormat: string | null;
     MediaListCollection: {
       lists: unknown[];
     };

--- a/app/utils/normalizeScore.ts
+++ b/app/utils/normalizeScore.ts
@@ -1,0 +1,59 @@
+/**
+ * AniList scoring systems and score normalization to a 0–100 scale.
+ *
+ * AniList supports multiple score formats per user. When comparing scores
+ * across users, the raw values must be converted to a common scale first,
+ * otherwise a POINT_5 score of 5 looks identical to a POINT_10 score of 5
+ * even though they represent completely different opinions (max vs mid).
+ */
+
+export type ScoreFormat =
+  | "POINT_100"
+  | "POINT_10_DECIMAL"
+  | "POINT_10"
+  | "POINT_5"
+  | "POINT_3"
+  | "SMILEY";
+
+/**
+ * Convert a raw AniList score to a 0–100 normalised value.
+ *
+ * A score of 0 always means "not rated" and is returned as-is so that
+ * callers can keep treating 0 as "no score".
+ */
+export function normalizeScoreTo100(
+  score: number,
+  format: ScoreFormat | string | null | undefined,
+): number {
+  if (score === 0) return 0;
+
+  switch (format) {
+    case "POINT_100":
+      // Already on a 0–100 scale
+      return score;
+
+    case "POINT_10_DECIMAL":
+      // 0–10 with one decimal place → multiply by 10
+      return score * 10;
+
+    case "POINT_10":
+      // 0–10 integer → multiply by 10
+      return score * 10;
+
+    case "POINT_5":
+      // 1–5 → map to 20/40/60/80/100
+      return (score / 5) * 100;
+
+    case "POINT_3":
+      // 1–3 (sad/neutral/happy) → map to ~33/67/100
+      return (score / 3) * 100;
+
+    case "SMILEY":
+      // AniList encodes smiley as 1 (sad), 2 (neutral), 3 (happy) internally
+      return (score / 3) * 100;
+
+    default:
+      // Unknown format: assume POINT_10 (AniList default) for safety
+      return score * 10;
+  }
+}

--- a/server/api/private/anilist.post.ts
+++ b/server/api/private/anilist.post.ts
@@ -45,6 +45,9 @@ type AniDashboardQueryResponse = AniListCollection<AniUserMediaEntry> & {
         minutesWatched?: number | null;
       } | null;
     } | null;
+    mediaListOptions?: {
+      scoreFormat?: string | null;
+    } | null;
   } | null;
 };
 function isPresent<T>(value: T | null | undefined): value is T {
@@ -112,6 +115,9 @@ export default defineEventHandler(async (event) => {
             minutesWatched
           }
         }
+        mediaListOptions {
+          scoreFormat
+        }
       }
       MediaListCollection(userName: $userName, type: ANIME) {
         lists {
@@ -147,6 +153,8 @@ export default defineEventHandler(async (event) => {
     episodesWatched: res.User?.statistics?.anime?.episodesWatched ?? null,
     minutesWatched: res.User?.statistics?.anime?.minutesWatched ?? null,
   };
+
+  const scoreFormat = res.User?.mediaListOptions?.scoreFormat ?? null;
 
   const lists = normalizeAniLists(res);
   /* -----------------------------
@@ -237,6 +245,7 @@ export default defineEventHandler(async (event) => {
   return {
     data: {
       stats,
+      scoreFormat,
       MediaListCollection: {
         lists: enrichedLists,
       },

--- a/tests/api.private-anilist-post.test.ts
+++ b/tests/api.private-anilist-post.test.ts
@@ -105,4 +105,35 @@ describe("api/private/anilist.post", () => {
     ])
     expect(prismaFindManyMock).toHaveBeenCalledTimes(1)
   })
+
+  it("returns scoreFormat from user mediaListOptions", async () => {
+    state.query = { user: "Leon" }
+    anilistRequestMock.mockResolvedValueOnce({
+      User: {
+        statistics: { anime: { episodesWatched: 100, minutesWatched: 2400 } },
+        mediaListOptions: { scoreFormat: "POINT_5" },
+      },
+      MediaListCollection: { lists: [] },
+    })
+    prismaFindManyMock.mockResolvedValueOnce([])
+
+    const mod = await import("../server/api/private/anilist.post")
+    const out = await mod.default({} as any)
+
+    expect(out.data.scoreFormat).toBe("POINT_5")
+  })
+
+  it("returns null scoreFormat when user has no mediaListOptions", async () => {
+    state.query = { user: "Leon" }
+    anilistRequestMock.mockResolvedValueOnce({
+      User: { statistics: { anime: {} } },
+      MediaListCollection: { lists: [] },
+    })
+    prismaFindManyMock.mockResolvedValueOnce([])
+
+    const mod = await import("../server/api/private/anilist.post")
+    const out = await mod.default({} as any)
+
+    expect(out.data.scoreFormat).toBeNull()
+  })
 })

--- a/tests/frontend/normalize-score.test.ts
+++ b/tests/frontend/normalize-score.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { normalizeScoreTo100 } from "../../app/utils/normalizeScore";
+
+describe("normalizeScoreTo100", () => {
+  it("returns 0 for unrated (score 0)", () => {
+    expect(normalizeScoreTo100(0, "POINT_10")).toBe(0);
+    expect(normalizeScoreTo100(0, "POINT_5")).toBe(0);
+    expect(normalizeScoreTo100(0, null)).toBe(0);
+  });
+
+  it("POINT_100: returns score unchanged", () => {
+    expect(normalizeScoreTo100(75, "POINT_100")).toBe(75);
+    expect(normalizeScoreTo100(100, "POINT_100")).toBe(100);
+  });
+
+  it("POINT_10_DECIMAL: multiplies by 10", () => {
+    expect(normalizeScoreTo100(8.5, "POINT_10_DECIMAL")).toBeCloseTo(85);
+    expect(normalizeScoreTo100(10, "POINT_10_DECIMAL")).toBeCloseTo(100);
+  });
+
+  it("POINT_10: multiplies by 10", () => {
+    expect(normalizeScoreTo100(8, "POINT_10")).toBe(80);
+    expect(normalizeScoreTo100(10, "POINT_10")).toBe(100);
+  });
+
+  it("POINT_5: maps 1-5 to 20/40/60/80/100", () => {
+    expect(normalizeScoreTo100(1, "POINT_5")).toBeCloseTo(20);
+    expect(normalizeScoreTo100(3, "POINT_5")).toBeCloseTo(60);
+    expect(normalizeScoreTo100(5, "POINT_5")).toBeCloseTo(100);
+  });
+
+  it("POINT_3: maps 1-3 to ~33/67/100", () => {
+    expect(normalizeScoreTo100(1, "POINT_3")).toBeCloseTo(33.33, 1);
+    expect(normalizeScoreTo100(2, "POINT_3")).toBeCloseTo(66.67, 1);
+    expect(normalizeScoreTo100(3, "POINT_3")).toBeCloseTo(100);
+  });
+
+  it("SMILEY: maps 1-3 to ~33/67/100", () => {
+    expect(normalizeScoreTo100(1, "SMILEY")).toBeCloseTo(33.33, 1);
+    expect(normalizeScoreTo100(3, "SMILEY")).toBeCloseTo(100);
+  });
+
+  it("unknown format: falls back to POINT_10 assumption", () => {
+    expect(normalizeScoreTo100(7, "UNKNOWN_FORMAT")).toBe(70);
+    expect(normalizeScoreTo100(7, null)).toBe(70);
+    expect(normalizeScoreTo100(7, undefined)).toBe(70);
+  });
+
+  it("normalizes equivalent ratings across formats to similar values", () => {
+    // A "max" rating on each scale should all normalize to 100
+    expect(normalizeScoreTo100(100, "POINT_100")).toBe(100);
+    expect(normalizeScoreTo100(10, "POINT_10")).toBe(100);
+    expect(normalizeScoreTo100(10, "POINT_10_DECIMAL")).toBe(100);
+    expect(normalizeScoreTo100(5, "POINT_5")).toBe(100);
+    expect(normalizeScoreTo100(3, "POINT_3")).toBeCloseTo(100);
+    expect(normalizeScoreTo100(3, "SMILEY")).toBeCloseTo(100);
+  });
+});


### PR DESCRIPTION
Closes #65

## Summary
- Normalize all user scores to a 0-100 scale before running taste comparison
- Ensures fair comparison regardless of the score scale users have configured on AniList

## Test plan
- [ ] Taste comparison works correctly between users with different score scales
- [ ] Scores display correctly in the comparison view

🤖 Generated with [Claude Code](https://claude.com/claude-code)