### PR TITLE
fix(#68): Status distribution shows all statuses, not only completed

### DIFF
--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -1089,7 +1089,7 @@ const statusLabels = computed<Record<string, string>>(() => ({
 }));
 const statusDistribution = computed(() => {
   const map: Record<string, number> = {};
-  for (const e of completedEntries.value) {
+  for (const e of entries.value) {
     map[e.status] = (map[e.status] || 0) + 1;
   }
   return Object.entries(map).map(([name, value]) => ({


### PR DESCRIPTION
Closes #68

## Summary
- Fixed `statusDistribution` in the Insights section iterating over `completedEntries.value` (only COMPLETED entries) instead of `entries.value`
- The chart now correctly shows all status categories: Completed, Planning, Current, Dropped, Paused, Repeating

## Test plan
- [ ] Status Distribution chart shows all statuses
- [ ] Counts match actual list entries per status

🤖 Generated with [Claude Code](https://claude.com/claude-code)