### PR TITLE
Handles AniList outages with a clear user message

### DIFF
--- a/app/composables/useApiError.ts
+++ b/app/composables/useApiError.ts
@@ -1,0 +1,19 @@
+import { isAxiosError } from "axios";
+
+function isAniListUnavailable(e: unknown): boolean {
+  if (!isAxiosError(e)) return false;
+  if (e.response?.status !== 403) return false;
+  const data = e.response?.data as { data?: { anilistUnavailable?: boolean } } | undefined;
+  return Boolean(data?.data?.anilistUnavailable);
+}
+
+export function resolveApiErrorMessage(
+  e: unknown,
+  t: (key: string) => string,
+  loadErrorKey: string,
+): string {
+  if (isAniListUnavailable(e)) {
+    return t("common.aniListUnavailable");
+  }
+  return `${t("common.errorPrefix")}: ${t(loadErrorKey)}`;
+}

--- a/app/i18n/translations.ts
+++ b/app/i18n/translations.ts
@@ -43,6 +43,7 @@ export const translations = {
       readMore: "Read more",
       showLess: "Show less",
       unofficialNotice: "AniStats is an unofficial app and is not affiliated with AniList or AniChart.",
+      aniListUnavailable: "AniList is currently unavailable due to a service outage. Please try again later.",
     },
     nav: {
       appName: "AniList Stats",
@@ -288,6 +289,7 @@ export const translations = {
       readMore: "Mehr anzeigen",
       showLess: "Weniger anzeigen",
       unofficialNotice: "AniStats ist eine inoffizielle App und steht in keiner Verbindung zu AniList oder AniChart.",
+      aniListUnavailable: "AniList ist aktuell aufgrund eines Ausfalls nicht erreichbar. Bitte versuche es später erneut.",
     },
     nav: {
       appName: "AniList Stats",

--- a/app/pages/calendar.vue
+++ b/app/pages/calendar.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { api } from "~/composables/useApi";
+import { resolveApiErrorMessage } from "~/composables/useApiError";
 
 definePageMeta({ title: "Calendar", middleware: "auth" });
 
@@ -119,7 +120,7 @@ async function loadAnime() {
     lastLoadedUser.value = currentUser;
   } catch (e) {
     console.error("[Calendar]", e);
-    error.value = `${t("common.errorPrefix")}: ${t("calendar.loadError")}`;
+    error.value = resolveApiErrorMessage(e, t, "calendar.loadError");
   } finally {
     loading.value = false;
   }

--- a/app/pages/combine.vue
+++ b/app/pages/combine.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { api } from "~/composables/useApi";
+import { resolveApiErrorMessage } from "~/composables/useApiError";
 import { normalizeAnilist } from "~/utils/normalizeAnilist";
 import type { AnimeEntry } from "~/types/anime";
 import type { ApiAnilistResponse } from "~/types/api";
@@ -69,7 +70,7 @@ async function loadAnime() {
     entries.value = normalizeAnilist(res.data.data.MediaListCollection.lists);
   } catch (e) {
     console.error("[Combine]", e);
-    error.value = `${t("common.errorPrefix")}: ${t("combine.loadError")}`;
+    error.value = resolveApiErrorMessage(e, t, "combine.loadError");
   } finally {
     loading.value = false;
   }

--- a/app/pages/compare.vue
+++ b/app/pages/compare.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { api } from "~/composables/useApi";
+import { resolveApiErrorMessage } from "~/composables/useApiError";
 import { normalizeAnilist } from "~/utils/normalizeAnilist";
 import { normalizeScoreTo100 } from "~/utils/normalizeScore";
 import type { AnimeEntry } from "~/types/anime";
@@ -115,7 +116,7 @@ async function loadSingleUser(username: string) {
     scoreFormatByUser.value[username] = res.data.data.scoreFormat ?? null;
   } catch (e) {
     console.error("[Compare]", e);
-    error.value = `${t("common.errorPrefix")}: ${t("compare.loadError")}`;
+    error.value = resolveApiErrorMessage(e, t, "compare.loadError");
   } finally {
     loading.value = false;
   }

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -1,5 +1,6 @@
 ﻿<script setup lang="ts">
 import { api } from "~/composables/useApi";
+import { resolveApiErrorMessage } from "~/composables/useApiError";
 import { normalizeAnilist } from "~/utils/normalizeAnilist";
 import type { AnimeEntry } from "~/types/anime";
 
@@ -110,7 +111,7 @@ async function loadAnime() {
     lastLoadedUser.value = currentUser;
   } catch (e) {
     console.error("[Dashboard]", e);
-    error.value = `${t("common.errorPrefix")}: ${t("dashboard.loadError")}`;
+    error.value = resolveApiErrorMessage(e, t, "dashboard.loadError");
     anilistStats.value = { episodesWatched: null, minutesWatched: null };
   } finally {
     loading.value = false;
@@ -605,7 +606,7 @@ async function loadAtlasCatalog() {
     atlasCatalogItems.value = res.data.items ?? [];
   } catch (e) {
     console.error("[Dashboard]", e);
-    atlasCatalogError.value = `${t("common.errorPrefix")}: ${t("dashboard.atlasCatalogLoadError")}`;
+    atlasCatalogError.value = resolveApiErrorMessage(e, t, "dashboard.atlasCatalogLoadError");
   } finally {
     atlasCatalogLoading.value = false;
   }

--- a/app/pages/genres.vue
+++ b/app/pages/genres.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { api } from "~/composables/useApi";
+import { resolveApiErrorMessage } from "~/composables/useApiError";
 import { normalizeAnilist } from "~/utils/normalizeAnilist";
 import { useRoute } from "vue-router";
 import type { AnimeEntry } from "~/types/anime";
@@ -49,7 +50,7 @@ async function loadAnime() {
     entries.value = normalizeAnilist(res.data.data.MediaListCollection.lists);
   } catch (e) {
     console.error("[Genres]", e);
-    error.value = `${t("common.errorPrefix")}: ${t("genres.loadError")}`;
+    error.value = resolveApiErrorMessage(e, t, "genres.loadError");
   } finally {
     loading.value = false;
   }

--- a/app/pages/history.vue
+++ b/app/pages/history.vue
@@ -2,6 +2,7 @@
 definePageMeta({ middleware: "auth", title: "History" })
 
 import HistoryCard from "~/components/HistoryCard.vue"
+import { resolveApiErrorMessage } from "~/composables/useApiError"
 
 const { t } = useLocale()
 
@@ -125,7 +126,7 @@ async function loadHistory() {
     results.value = [...(res ?? [])].sort((a, b) => completedKey(b) - completedKey(a))
   } catch (e) {
     console.error("[History]", e)
-    error.value = `${t("common.errorPrefix")}: ${t("history.loadError")}`
+    error.value = resolveApiErrorMessage(e, t, "history.loadError")
   } finally {
     loading.value = false
   }

--- a/app/pages/recommendation.vue
+++ b/app/pages/recommendation.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { api } from "~/composables/useApi";
+import { resolveApiErrorMessage } from "~/composables/useApiError";
 import type {
   ApiGenreTagsResponse,
   ApiRecommendationItem,
@@ -124,7 +125,7 @@ async function loadRecommendations() {
     expandedTagCards.value = {};
   } catch (e) {
     console.error("[Recommendation]", e);
-    error.value = `${t("common.errorPrefix")}: ${t("recommendation.loadError")}`;
+    error.value = resolveApiErrorMessage(e, t, "recommendation.loadError");
   } finally {
     loading.value = false;
   }

--- a/app/pages/relations.vue
+++ b/app/pages/relations.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { api } from "~/composables/useApi";
+import { resolveApiErrorMessage } from "~/composables/useApiError";
 import type {
   ApiRelationChainItem,
   ApiRelationGroup,
@@ -112,7 +113,7 @@ async function loadRelations() {
     });
   } catch (e) {
     console.error("[Relations]", e);
-    error.value = `${t("common.errorPrefix")}: ${t("relations.loadError")}`;
+    error.value = resolveApiErrorMessage(e, t, "relations.loadError");
   } finally {
     loading.value = false;
   }

--- a/app/pages/tags.vue
+++ b/app/pages/tags.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { api } from "~/composables/useApi";
+import { resolveApiErrorMessage } from "~/composables/useApiError";
 import { normalizeAnilist } from "~/utils/normalizeAnilist";
 import type { AnimeEntry } from "~/types/anime";
 import GameCard from "../components/GameCard.vue";
@@ -48,7 +49,7 @@ async function loadAnime() {
     entries.value = normalizeAnilist(res.data.data.MediaListCollection.lists);
   } catch (e) {
     console.error("[Tags]", e);
-    error.value = `${t("common.errorPrefix")}: ${t("tags.loadError")}`;
+    error.value = resolveApiErrorMessage(e, t, "tags.loadError");
   } finally {
     loading.value = false;
   }

--- a/services/anilist/anilistClient.ts
+++ b/services/anilist/anilistClient.ts
@@ -1,3 +1,4 @@
+import { createError } from "h3";
 import { enqueueAniList } from "./anilistQueue";
 
 const inFlightRequests = new Map<string, Promise<unknown>>();
@@ -32,6 +33,14 @@ async function performAniListRequest<T>(
 
       await sleep(waitMs);
       return performAniListRequest(query, variables, attempt + 1);
+    }
+
+    if (res.status === 403) {
+      throw createError({
+        statusCode: 403,
+        statusMessage: "AniList API unavailable",
+        data: { anilistUnavailable: true },
+      });
     }
 
     if (!res.ok) {


### PR DESCRIPTION
Detects 403 responses from AniList caused by service outages and surfaces a dedicated, translated error message instead of the generic load error, improving clarity when AniList itself is down.

Adds a shared helper to resolve API error messages and wires it into all pages that fetch AniList data, keeping error handling consistent across the app.